### PR TITLE
Orb publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,21 @@ jobs:
     steps:
       - checkout
       - run: "scripts/validate_orbs.sh"
+  publish_orbs:
+    executor: cli
+    steps:
+      - checkout
+      - run: "scripts/publish_bumped_orbs.sh"
 
 workflows:
   version: 2
-  validate:
+  build:
     jobs:
-      - validate_orbs
+      - validate_orbs:
+          branches:
+            ignore:
+              - master
+      - publish_orbs:
+          branches:
+            only:
+              - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,13 @@ workflows:
   build:
     jobs:
       - validate_orbs:
-          branches:
-            ignore:
-              - master
+          filters:
+            branches:
+              ignore:
+                - master
       - publish_orbs:
-          branches:
-            only:
-              - master
+          context: circleci-api
+          filters:
+            branches:
+              only:
+                - master

--- a/scripts/publish_bumped_orbs.sh
+++ b/scripts/publish_bumped_orbs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for orb in $(ls ./src); do
+  ./scripts/publish_orb.sh $orb
+done

--- a/scripts/publish_bumped_orbs.sh
+++ b/scripts/publish_bumped_orbs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 for orb in $(ls ./src); do
   ./scripts/publish_orb.sh $orb

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION_REGEX="[0-9]\.[0-9]\.[0-9]"
+RED="\x1B[31m"
+
+print() {
+  reset="\x1B[0m"
+  color=$1
+  echo "$color$2$reset"
+}
+
+echo ""
+echo "Running publish for orb $1..."
+
+ORB="$1"
+YML_PATH="./src/$ORB/$ORB.yml"
+
+if [ ! -f "$YML_PATH" ]; then
+  echo "No orb exists at $YML_PATH"
+  exit 1
+fi
+
+VERSION_COMMENT=$(head -n 1 $YML_PATH)
+VERSION=$(echo $VERSION_COMMENT | grep -o "$VERSION_REGEX")
+
+# Ensure the version is defined and that the version comment actually is a comment...
+if [ -z $VERSION ] || [ ! "${VERSION_COMMENT:0:1}" == "#" ]; then
+  echo ""
+  print $RED "Orb at $YML_PATH does not have a version comment"
+  print $RED "Add something like '# Orb Version 1.0.0' at the top of the file"
+  print $RED "That version will be used as the published version"
+  exit 1
+fi
+
+echo "Ensuring orb is valid..."
+
+circleci orb validate $YML_PATH
+
+LAST_PUBLISHED=$(circleci orb info artsy/$ORB | grep -i latest | grep -o "$VERSION_REGEX")
+
+# TODO: Fail if $LAST_PUBLISHED > $VERSION
+echo "Trying to publish $VERSION, last known publish version $LAST_PUBLISHED"
+
+circleci orb publish $YML_PATH artsy/$ORB@$VERSION

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 VERSION_REGEX="[0-9]\.[0-9]\.[0-9]"
 RED="\x1B[31m"
 
+TOKEN=""
+if [ ! -z "${CIRCLECI_API_KEY:-}" ]; then
+  TOKEN="--token $CIRCLECI_API_KEY"
+fi
+
 print() {
   reset="\x1B[0m"
   color=$1
@@ -47,4 +52,4 @@ circleci orb validate $YML_PATH
 
 echo "Trying to publish $VERSION, last known publish version $LAST_PUBLISHED"
 
-circleci orb publish $YML_PATH artsy/$ORB@$VERSION
+circleci orb publish $YML_PATH artsy/$ORB@$VERSION $TOKEN

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -33,13 +33,18 @@ if [ -z $VERSION ] || [ ! "${VERSION_COMMENT:0:1}" == "#" ]; then
   exit 1
 fi
 
-echo "Ensuring orb is valid..."
-
-circleci orb validate $YML_PATH
 
 LAST_PUBLISHED=$(circleci orb info artsy/$ORB | grep -i latest | grep -o "$VERSION_REGEX")
 
 # TODO: Fail if $LAST_PUBLISHED > $VERSION
+if [ $VERSION == $LAST_PUBLISHED ]; then
+  echo "artsy/$ORB@$VERSION is the latest, skipping publish"
+  exit 0
+fi
+
+echo "Ensuring orb is valid..."
+circleci orb validate $YML_PATH
+
 echo "Trying to publish $VERSION, last known publish version $LAST_PUBLISHED"
 
 circleci orb publish $YML_PATH artsy/$ORB@$VERSION

--- a/scripts/validate_orbs.sh
+++ b/scripts/validate_orbs.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
+set -o pipefail
 
-for orb in src/**/*.yml; do circleci orb validate $orb; done
+VERSION_REGEX="[0-9]\.[0-9]\.[0-9]"
+
+for orb in src/**/*.yml; do 
+  version_comment=$(head -n 1 $orb)
+  version=$(echo $version_comment | grep -o "$VERSION_REGEX")
+
+  if [ -z $version ] || [ ! "${version_comment:0:1}" == "#" ]; then
+    echo "Every orb is expected to have a version comment on line 1"
+    echo "It should look something like '# Orb Version 1.0.0'"
+    exit 1
+  fi
+
+  circleci orb validate $orb 
+done


### PR DESCRIPTION
Fixes #2 

This sets up the autopublishing of orbs once they've merged into master. 

I didn't mess w/ circle's publishing orbs because it just seemed like a lot of effort. This way we can control how and when our orbs publish. 

I've kinda set up a system where every orb has to have a comment at the top of the file containing its version. That'll be the version that's deployed. It just feels nice to be able to look at the file and know what version it is. 