### PR TITLE
Fail orb validation if an orb changes but the version doesn't

### DIFF
--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -17,6 +17,11 @@ get_orb_version() {
   echo $VERSION
 }
 
+get_published_orb_version() {
+  LAST_PUBLISHED=$(circleci orb info artsy/$1 | grep -i latest | grep -o "$VERSION_REGEX")
+  echo $LAST_PUBLISHED
+}
+
 compare_version() {
   local GREATER=">"
   local LESS="<"

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -12,13 +12,13 @@ echo ""
 echo "Beginning publish of artsy/$1 orb"
 
 ORB="$1"
-ORB_PATH=$(get_orb_path $ORB)
 
 # Ensuring orb is valid
 ./scripts/validate_orb.sh $ORB
 
+ORB_PATH=$(get_orb_path $ORB)
 VERSION=$(get_orb_version $ORB)
-LAST_PUBLISHED=$(circleci orb info artsy/$ORB | grep -i latest | grep -o "$VERSION_REGEX")
+LAST_PUBLISHED=$(get_published_orb_version $ORB)
 
 case $(compare_version $VERSION $LAST_PUBLISHED) in
   "=")

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -15,6 +15,7 @@ fi
 
 VERSION=$(get_orb_version $ORB)
 VERSION_COMMENT=$(head -n 1 $ORB_PATH)
+PUBLISHED_VERSION=$(get_published_orb_version $ORB)
 
 # Ensure the version is defined and that the version comment actually is a comment...
 if [ -z $VERSION ] || [ ! "${VERSION_COMMENT:0:1}" == "#" ]; then
@@ -24,5 +25,22 @@ if [ -z $VERSION ] || [ ! "${VERSION_COMMENT:0:1}" == "#" ]; then
   echo "That version will be used as the published version"
   return
 fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "master" ]; then
+
+  CHANGED_FILES=$(git diff --name-only HEAD..master)
+  UPDATED_FILES=$(git status -s | cut -c4-)
+  ALL_CHANGES=("${CHANGED_FILES[@]}" "${UPDATED_FILES[@]}")
+  for file in ${ALL_CHANGES[@]}; do
+    if [[ "$ORB_PATH" == *"$file" ]] && [[ "$VERSION" == "$PUBLISHED_VERSION" ]]; then
+      echo ""
+      echo "artsy/$ORB has been updated since master but hasn't had its version bumped."
+      echo "Update its version in $ORB_PATH"
+      exit 1
+    fi
+  done
+
+fi 
 
 circleci orb validate $ORB_PATH


### PR DESCRIPTION
Fixes #7.

When an orb is being validated on a development branch and the contents of the orb has changed since master we now check to ensure the version was bumped. If there's no version bump, validation fails for that orb. 