### PR TITLE
Update yarn/auto-pr-check to work outside the context of a fork

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.0.5
+# Orb Version 0.0.6
 
 version: 2.1
 description: Common yarn commands
@@ -140,4 +140,6 @@ jobs:
           command: |
             if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
               yarn auto pr-check --pr $CIRCLE_PR_NUMBER --url $CIRCLE_PULL_REQUEST
+            elif
+              yarn auto pr-check --pr ${CIRCLE_PR_NUMBER##https:/*/} --url $CIRCLE_PULL_REQUEST
             fi

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -141,5 +141,5 @@ jobs:
             if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
               yarn auto pr-check --pr $CIRCLE_PR_NUMBER --url $CIRCLE_PULL_REQUEST
             elif
-              yarn auto pr-check --pr ${CIRCLE_PR_NUMBER##https:/*/} --url $CIRCLE_PULL_REQUEST
+              yarn auto pr-check --pr ${CIRCLE_PULL_REQUEST##https:/*/} --url $CIRCLE_PULL_REQUEST
             fi


### PR DESCRIPTION
`auto-release-cli` has a command `auto pr-check` which validates the state of a PR. It also works pretty well as an early indicator of problems that might be happening with auto-release. I was relying on `$CIRCLE_PR_NUMBER` to figure out which PR auto check should use, but that's only valid on forks. I added an alternative that just grabs the PR number from the pull request link. 