### PR TITLE
Notify Slack after releasing a new orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,22 @@ jobs:
     executor: cli
     steps:
       - checkout
-      - run: "scripts/validate_orbs.sh"
+      - run:
+          name: Validate orbs
+          command: scripts/validate_orbs.sh
   publish_orbs:
     executor: cli
     steps:
       - checkout
-      - run: "scripts/publish_orbs.sh"
+      - run:
+          name: Install slack notifier
+          command: |
+            curl --location --output ./slack \
+            https://github.com/cloudposse/slack-notifier/releases/download/0.2.0/slack-notifier_linux_amd64
+            chmod +x ./slack
+      - run:
+          name: Publish orbs
+          command: scripts/publish_orbs.sh
 
 workflows:
   version: 2

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -42,3 +42,10 @@ case $(compare_version $VERSION $LAST_PUBLISHED) in
 esac
 
 circleci orb publish $ORB_PATH artsy/$ORB@$VERSION $TOKEN
+
+./slack \
+  -color "good" \
+  -title "Circle CI $ORB orb v$VERSION published!" \
+  -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/artsy/orbs/tree/master}" \
+  -user_name "artsyit" \
+  -icon_emoji ":crystal_ball:"


### PR DESCRIPTION
Fixes #15 

> artsyit (:crystall_ball:): Circle CI {name} orb v{version} published!

The Slack message title links to the Circle CI build.

![2019-01-15-160800_561x140_scrot](https://user-images.githubusercontent.com/123595/51210039-baaa3000-18df-11e9-8442-b3491a58ea2a.png)

ticket: https://artsyproduct.atlassian.net/browse/DISCO-679 :lock: 