### PR TITLE
Allow auto-release job to be configurable

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.5
+# Orb Version 0.1.6
 
 version: 2.1
 description: Common yarn commands
@@ -131,9 +131,13 @@ jobs:
 
   auto-release:
     executor: node/build
+    parameters:
+      args:
+        type: string
+        default: ''
     steps:
       - run-release:
-          script: npx auto shipit
+          script: npx auto shipit << parameters.args >>
 
   auto-pr-check:
     executor: node/build


### PR DESCRIPTION
I want to be able to pass args to auto (specifically so I can debug failing cases). 