### PR TITLE
Add prettier check job

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -90,6 +90,12 @@ jobs:
       - run-script:
           script: relay
 
+  prettier-check:
+    executor: node/build
+    steps:
+      - run-script:
+          script: prettier-check
+
   type-check:
     executor: node/build
     steps:


### PR DESCRIPTION
Prettier now has a `check` flag that will output a more human-friendly message:

https://prettier.io/docs/en/cli.html#check

So I'm adding a job here that can run that particular script. My plan is to add this over on Palette to start.