### PR TITLE
[WIP] Add jest job, simplify test job

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.2.0
+# Orb Version 1.0.0
 
 version: 2.1
 description: Common yarn commands
@@ -98,21 +98,27 @@ jobs:
 
   test:
     executor: node/build
+    parameters:
+      args:
+        type: string
+        default: ""
+    steps:
+      - run-script:
+          script: test << parameters.args >>
+
+  jest:
+    executor: node/build
     environment:
       JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
     parameters:
-      ci-stats:
-        type: boolean
-        default: false
       args:
         type: string
         default: -w 4
     steps:
-      # Runs jest tests with 6 concurrent workers. Without limiting it to 6
-      # workers Jest will spawn many memory hungry workers and ultimately
-      # starve the job for memory.
       - run-script:
-          script: test <<# parameters.ci-stats >>--reporters=default --reporters=jest-junit<</ parameters.ci-stats >> << parameters.args >>
+          script: jest --reporters=default --reporters=jest-junit << parameters.args >>
+      - store_test_results:
+          path: reports/junit/js-test-results.xml
 
   update-cache:
     executor: node/build


### PR DESCRIPTION
This PR represents a breaking change that does two things

1. Simplifies the `test` job to have nothing related to jest, but keep it otherwise api compatible. Now it just functions to call the test npm script.
2. Introduces a `jest` job that specifically runs jest and also reports test results to circle. This requires another module (`jest-junit`) to be installed to function. 