### PR TITLE
Ensure new orbs can be published

### DIFF
--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -17,6 +17,13 @@ get_orb_version() {
   echo $VERSION
 }
 
+is_orb_published() {
+  PUBLISHED=$(circleci orb list artsy | grep artsy/$1)
+  if [ ! -z "$PUBLISHED" ]; then
+    echo "true"
+  fi
+}
+
 get_published_orb_version() {
   LAST_PUBLISHED=$(circleci orb info artsy/$1 | grep -i latest | grep -o "$VERSION_REGEX")
   echo $LAST_PUBLISHED

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -18,28 +18,34 @@ ORB="$1"
 
 ORB_PATH=$(get_orb_path $ORB)
 VERSION=$(get_orb_version $ORB)
-LAST_PUBLISHED=$(get_published_orb_version $ORB)
+IS_PUBLISHED=$(is_orb_published $ORB)
 
-case $(compare_version $VERSION $LAST_PUBLISHED) in
-  "=")
-    echo "artsy/$ORB@$VERSION is the latest, skipping publish"
-    exit 0
-    ;;
-  "<")
-    echo "artsy/$ORB@$LAST_PUBLISHED is the latest, cannot publish older version $VERSION"
-    echo "Please update $ORB_PATH to have a version greater than $LAST_PUBLISHED"
-    exit 1
-    ;;
-  ">")
-    echo "Preparing to bump artsy/$ORB from $LAST_PUBLISHED to $VERSION"
-    ;;
-  *)
-    echo "Version comparison for artsy/$ORB failed."
-    echo "Current version: $VERSION"
-    echo "Published version: $LAST_PUBLISHED"
-    exit 1
-    ;;
-esac
+if [ -z "$IS_PUBLISHED" ]; then
+
+  LAST_PUBLISHED=$(get_published_orb_version $ORB)
+
+  case $(compare_version $VERSION $LAST_PUBLISHED) in
+    "=")
+      echo "artsy/$ORB@$VERSION is the latest, skipping publish"
+      exit 0
+      ;;
+    "<")
+      echo "artsy/$ORB@$LAST_PUBLISHED is the latest, cannot publish older version $VERSION"
+      echo "Please update $ORB_PATH to have a version greater than $LAST_PUBLISHED"
+      exit 1
+      ;;
+    ">")
+      echo "Preparing to bump artsy/$ORB from $LAST_PUBLISHED to $VERSION"
+      ;;
+    *)
+      echo "Version comparison for artsy/$ORB failed."
+      echo "Current version: $VERSION"
+      echo "Published version: $LAST_PUBLISHED"
+      exit 1
+      ;;
+  esac
+
+fi
 
 circleci orb publish $ORB_PATH artsy/$ORB@$VERSION $TOKEN
 

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -20,7 +20,7 @@ ORB_PATH=$(get_orb_path $ORB)
 VERSION=$(get_orb_version $ORB)
 IS_PUBLISHED=$(is_orb_published $ORB)
 
-if [ -z "$IS_PUBLISHED" ]; then
+if [ ! -z "$IS_PUBLISHED" ]; then
 
   LAST_PUBLISHED=$(get_published_orb_version $ORB)
 


### PR DESCRIPTION
Had a bash failure on the deploy of the hokusai orb. 

It was checking for the published version of the orb (and it wasn't published yet) which caused the command to fail. I've added a new function to check if the orb is published before trying to do the last version calculations. 