### PR TITLE
Create orb if it's not already on the registry

### DIFF
--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -45,6 +45,9 @@ if [ ! -z "$IS_PUBLISHED" ]; then
       ;;
   esac
 
+else
+  echo "Orb artsy/$ORB isn't in the registry. Creating its registry entry..."
+  circleci orb create artsy/$ORB
 fi
 
 circleci orb publish $ORB_PATH artsy/$ORB@$VERSION $TOKEN


### PR DESCRIPTION
Another thing I missed. 

If an orb isn't already in the registry then you have to run `circleci orb create artsy/<orb>` first _before_ running publish. 

🤞 