### PR TITLE
Temporarily lock auto version

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -148,7 +148,7 @@ jobs:
         default: ""
     steps:
       - run-release:
-          script: npx auto shipit << parameters.args >> $AUTO_ARGS
+          script: npx auto@6.5.1 shipit << parameters.args >> $AUTO_ARGS
 
   auto-pr-check:
     executor: node/build

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.1.0
+# Orb Version 1.1.1
 
 version: 2.1
 description: Common yarn commands


### PR DESCRIPTION
cc @hipstersmoothie

[auto](https://github.com/intuit/auto) v7 is failing with the below error and I'm uncertain as to if it's related to npx or if it's a general error. For now I'm going to lock the version to the last `6.*` release.

```
npx: installed 149 in 9.409s
TypeError: plugin is not a constructor
    at Object.loadPlugin [as default] (/home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/utils/load-plugins.js:51:12)
    at /home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/auto.js:1013:67
    at Array.map (<anonymous>)
    at Auto.loadPlugins (/home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/auto.js:1013:14)
    at Auto.<anonymous> (/home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/auto.js:166:30)
    at step (/home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/auto.js:43:23)
    at Object.next (/home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/auto.js:24:53)
    at fulfilled (/home/circleci/.npm/_npx/111/lib/node_modules/auto/node_modules/@auto-it/core/dist/auto.js:15:58)
Exited with code 1
```