### PR TITLE
Publish canary orbs on PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,6 @@ executors:
       - image: circleci/circleci-cli
 
 jobs:
-  validate_orbs:
-    executor: cli
-    steps:
-      - checkout
-      - run:
-          name: Validate orbs
-          command: scripts/validate_orbs.sh
   publish_orbs:
     executor: cli
     steps:
@@ -28,17 +21,7 @@ jobs:
           command: scripts/publish_orbs.sh
 
 workflows:
-  version: 2
   build:
     jobs:
-      - validate_orbs:
-          filters:
-            branches:
-              ignore:
-                - master
       - publish_orbs:
           context: circleci-api
-          filters:
-            branches:
-              only:
-                - master

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
-  TERM="xterm"
+  _red="\e[31m"
+  _green="\e[32m"
+  _yellow="\e[33m"
+  _reset="\e[0m"
+else
+  _red=`tput -T $TERM setaf 1`
+  _green=`tput -T $TERM setaf 2`
+  _yellow=`tput -T $TERM setaf 3`
+  _reset=`tput -T $TERM sgr0`
 fi
 
-COLORS_ENABLED=$([ -x "$(command -v tput)" ] && echo "true")
-
-_red=`tput -T $TERM setaf 1`
-_green=`tput -T $TERM setaf 2`
-_yellow=`tput -T $TERM setaf 3`
-_reset=`tput -T $TERM sgr0`
-
 COLOR() {
-  [ ! -z COLORS_ENABLED ] && echo "$1$2${_reset}" || echo "$2"
+  echo "$1$2${_reset}"
 }
 
 RED() {

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
-  TERM="xterm-256color"
+  TERM="xterm"
 fi
 
 COLORS_ENABLED=$([ -x "$(command -v tput)" ] && echo "true")

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -13,7 +13,7 @@ else
 fi
 
 COLOR() {
-  echo "$1$2${_reset}"
+  echo -e "$1$2${_reset}"
 }
 
 RED() {

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z "$TERM" ]; then
+  export TERM="vt100"
+fi
+
 COLORS_ENABLED=$([ -x "$(command -v tput)" ] && echo "true")
 
 _red=`tput setaf 1`

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+COLORS_ENABLED=$([ -x "$(command -v tput)" ] && echo "true")
+
+_red=`tput setaf 1`
+_red=`tput setaf 2`
+_yellow=`tput setaf 3`
+_reset=`tput sgr0`
+
+COLOR() {
+  [ ! -z COLORS_ENABLED ] && echo "$1$2${_reset}" || echo "$2"
+}
+
+RED() {
+  echo $(COLOR $_red "$1")
+}
+
+GREEN() {
+  echo $(COLOR $_green "$1")
+}
+
+YELLOW() {
+  echo $(COLOR $_yellow "$1")
+}

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 if [ -z "$TERM" ]; then
-  export TERM="vt100"
+  TERM="vt100"
 fi
 
 COLORS_ENABLED=$([ -x "$(command -v tput)" ] && echo "true")
 
-_red=`tput setaf 1`
-_red=`tput setaf 2`
-_yellow=`tput setaf 3`
-_reset=`tput sgr0`
+_red=`tput -T $TERM setaf 1`
+_red=`tput -T $TERM setaf 2`
+_yellow=`tput -T $TERM setaf 3`
+_reset=`tput -T $TERM sgr0`
 
 COLOR() {
   [ ! -z COLORS_ENABLED ] && echo "$1$2${_reset}" || echo "$2"

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-if [ -z "$TERM" ]; then
-  TERM="vt100"
+if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
+  TERM="xterm-256color"
 fi
 
 COLORS_ENABLED=$([ -x "$(command -v tput)" ] && echo "true")
 
 _red=`tput -T $TERM setaf 1`
-_red=`tput -T $TERM setaf 2`
+_green=`tput -T $TERM setaf 2`
 _yellow=`tput -T $TERM setaf 3`
 _reset=`tput -T $TERM sgr0`
 

--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -18,8 +18,8 @@ get_orb_version() {
 }
 
 is_orb_published() {
-  PUBLISHED=$(circleci orb list artsy | grep artsy/$1)
-  if [ ! -z "$PUBLISHED" ]; then
+  PUBLISHED=$(circleci orb info artsy/$1 > /dev/null 2>&1; echo $?)
+  if [ "$PUBLISHED" -eq "0" ]; then
     echo "true"
   fi
 }

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -14,9 +14,11 @@ set -euo pipefail
 . ./scripts/orb_utils.sh
 . ./scripts/colors.sh
 
+
 echo ""
 echo "Beginning publish of artsy/$1 orb"
 echo ""
+
 
 # Build CircleCI token argument
 TOKEN=""
@@ -24,8 +26,7 @@ if [ ! -z "${CIRCLECI_API_KEY:-}" ]; then
   TOKEN="--token $CIRCLECI_API_KEY"
 fi
 
-# Grab the current git branch
-BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+
 
 # Set a dry-run mode
 if [ ! -z "$DRY_RUN" ] || [ -z "$CI" ]; then
@@ -33,6 +34,9 @@ if [ ! -z "$DRY_RUN" ] || [ -z "$CI" ]; then
   echo $(YELLOW "[Running in dry-run mode]")
 fi 
 
+
+# Grab the current git branch
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 
 # Build the dev version prefix. When not on the master branch this will be
 # used to publish a dev version of the orb. That can be pulled in using

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -24,6 +24,10 @@ echo ""
 TOKEN=""
 if [ ! -z "${CIRCLECI_API_KEY:-}" ]; then
   TOKEN="--token $CIRCLECI_API_KEY"
+else
+  echo $(RED "Must provide CIRCLECI_API_KEY env var")
+  echo ""
+  exit 1
 fi
 
 

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -88,7 +88,7 @@ else
   FULL_VERSION="$VERSION"
 fi
 
-# If the orb has been previously published (i.e. it already exists in cicle's registry)
+# If the orb has been previously published (i.e. it already exists in circle's registry)
 if [ ! -z "$IS_PUBLISHED" ]; then
 
   LAST_PUBLISHED=$(get_published_orb_version $ORB)

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -1,60 +1,128 @@
 #!/bin/bash
 set -euo pipefail
 
-. ./scripts/orb_utils.sh
+# This script is called from publish_orbs.sh
+#
+# Usage:
+# publish_orb.sh <orb_name>
+#
+# When $CI isn't set or $DRY_RUN is set this script will
+# skip any actual publishing steps. This means it _shouldn't_
+# do any publishing when you're testing locally.
 
+# "import" some utility functions
+. ./scripts/orb_utils.sh
+. ./scripts/colors.sh
+
+echo ""
+echo "Beginning publish of artsy/$1 orb"
+echo ""
+
+# Build CircleCI token argument
 TOKEN=""
 if [ ! -z "${CIRCLECI_API_KEY:-}" ]; then
   TOKEN="--token $CIRCLECI_API_KEY"
 fi
 
-echo ""
-echo "Beginning publish of artsy/$1 orb"
+# Grab the current git branch
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+
+# Set a dry-run mode
+if [ ! -z "$DRY_RUN" ] || [ -z "$CI" ]; then
+  DRY_RUN="true"
+  echo $(YELLOW "[Running in dry-run mode]")
+fi 
+
+
+# Build the dev version prefix. When not on the master branch this will be
+# used to publish a dev version of the orb. That can be pulled in using
+# artsy/<orb-name>@dev:<version>. This is useful for testing purposes.
+#
+# This will be referred to as "dev mode" in later comments
+DEV=""
+if [ "$BRANCH" != "master" ]; then
+  DEV="dev:"
+  echo $(YELLOW "[Running in dev mode]")
+fi
+
+# When in dev mode
+if [ ! -z "$DEV" ]; then
+  echo ""
+  echo "This will be a dev deployment (prefixed with dev:)"
+fi
+
 
 ORB="$1"
 
-# Ensuring orb is valid
+# Ensure the orb is valid
 ./scripts/validate_orb.sh $ORB
 
 ORB_PATH=$(get_orb_path $ORB)
 VERSION=$(get_orb_version $ORB)
 IS_PUBLISHED=$(is_orb_published $ORB)
 
+# If the orb has been previously published (i.e. it already exists in cicle's registry)
 if [ ! -z "$IS_PUBLISHED" ]; then
 
   LAST_PUBLISHED=$(get_published_orb_version $ORB)
 
   case $(compare_version $VERSION $LAST_PUBLISHED) in
     "=")
-      echo "artsy/$ORB@$VERSION is the latest, skipping publish"
-      exit 0
+      # When not in dev mode
+      if [ -z "$DEV" ]; then
+        echo "artsy/$ORB@$VERSION is the latest, skipping publish"
+        exit 0
+      fi
       ;;
     "<")
-      echo "artsy/$ORB@$LAST_PUBLISHED is the latest, cannot publish older version $VERSION"
-      echo "Please update $ORB_PATH to have a version greater than $LAST_PUBLISHED"
+      echo $(RED "artsy/$ORB@$LAST_PUBLISHED is the latest, cannot publish older version $VERSION")
+      echo $(RED "Please update $ORB_PATH to have a version greater than $LAST_PUBLISHED")
       exit 1
       ;;
     ">")
-      echo "Preparing to bump artsy/$ORB from $LAST_PUBLISHED to $VERSION"
+      # when not in dev mode
+      if [ -z "$DEV" ]; then
+        echo "Preparing to bump artsy/$ORB from $LAST_PUBLISHED to $VERSION"
+      fi
       ;;
     *)
-      echo "Version comparison for artsy/$ORB failed."
-      echo "Current version: $VERSION"
-      echo "Published version: $LAST_PUBLISHED"
+      echo $(RED "Version comparison for artsy/$ORB failed.")
+      echo $(RED "Current version: $VERSION")
+      echo $(RED "Published version: $LAST_PUBLISHED")
       exit 1
       ;;
   esac
 
+  # When in dev mode
+  if [ ! -z "$DEV" ];then
+    echo "Preparing to publish dev orb artsy/$ORB@$DEV$VERSION"
+  fi
+
 else
   echo "Orb artsy/$ORB isn't in the registry. Creating its registry entry..."
   circleci orb create artsy/$ORB $TOKEN --no-prompt
+  echo "Orb created, prepaing to publish artsy/$ORB@$DEV$VERSION"
 fi
 
-circleci orb publish $ORB_PATH artsy/$ORB@$VERSION $TOKEN
 
-./slack \
-  -color "good" \
-  -title "Circle CI $ORB orb v$VERSION published!" \
-  -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/artsy/orbs/tree/master}" \
-  -user_name "artsyit" \
-  -icon_emoji ":crystal_ball:"
+# Publish to CircleCI (when it's not a dry run)
+if [ -z "$DRY_RUN" ]; then
+  circleci orb publish $ORB_PATH artsy/$ORB@$DEV$VERSION $TOKEN
+else
+  echo "$(YELLOW "[skipped]") circleci orb publish $ORB_PATH artsy/$ORB@$DEV$VERSION"
+fi
+
+
+# Publish to slack (when it's neither a dry run or dev mode)
+if [ -z "$DRY_RUN" ] && [ -z "$DEV" ]; then
+  ./slack \
+    -color "good" \
+    -title "Circle CI $ORB orb v$VERSION published!" \
+    -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/artsy/orbs/tree/master}" \
+    -user_name "artsyit" \
+    -icon_emoji ":crystal_ball:"
+
+# When it's a dry run but not in dev mode
+elif [ -z "$DRY_RUN" ]; then
+  echo "[skipped] Post to slack: Circle CI $ORB orb v$VERSION published"
+fi

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -28,10 +28,16 @@ fi
 
 
 
+# Make sure DRY_RUN and CI are defined
+DRY_RUN=${DRY_RUN:-""}
+CI=${CI:-""}
+
 # Set a dry-run mode
-if [ ! -z "${DRY_RUN:-}" ] || [ -z "${CI:-}" ]; then
+if [ ! -z "$DRY_RUN" ] || [ -z "$CI" ]; then
   DRY_RUN="true"
   echo $(YELLOW "[Running in dry-run mode]")
+else
+  DRY_RUN=""
 fi 
 
 

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -29,7 +29,7 @@ fi
 
 
 # Set a dry-run mode
-if [ ! -z "$DRY_RUN" ] || [ -z "$CI" ]; then
+if [ ! -z "${DRY_RUN:-}" ] || [ -z "${CI:-}" ]; then
   DRY_RUN="true"
   echo $(YELLOW "[Running in dry-run mode]")
 fi 

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 . ./scripts/orb_utils.sh
 
 ORB="$1"
+echo ""
 echo "Validating artsy/$1 orb"
 
 ORB_PATH=$(get_orb_path $ORB)
@@ -49,3 +50,5 @@ if [ ! -z "$IS_PUBLISHED" ]; then
 fi
 
 circleci orb validate $ORB_PATH
+
+echo ""


### PR DESCRIPTION
This updates our orb publishing process to publish canary versions of the orbs on each PR. 

So if you're working on version `1.0.0` of the hokusai orb in a PR, then every CI build will publish `artsy/hokusai@dev:1.0.0.*`. This version can be used in another project to test your changes before merging. 

The `.*` at the end of the dev version is either the PR number or the sha of the commit being deployed if the pr number doesn't exist. 

So a full version will either look like

`artsy/hokusai@dev:1.0.0.36`

or

`artsy/hokusai@dev:1.0.0.ae518e1bdbcdc3a0584eaeb047a106b4a8881bb0`

---

I did some other things:

- General cleanup
- Many more comments
- Prettified the output, now w/ color
- Added a dry run mode (default when `CI` not set, but can be trigged by `DRY_RUN`)

Let me know if you have any questions. 