### PR TITLE
Make auto version configurable

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -145,7 +145,7 @@ jobs:
     parameters:
       version:
         type: string
-        default: latest
+        default: 6.5.1
       args:
         type: string
         default: ""

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -143,12 +143,15 @@ jobs:
   auto-release:
     executor: node/build
     parameters:
+      version:
+        type: string
+        default: 6.5.1
       args:
         type: string
         default: ""
     steps:
       - run-release:
-          script: npx auto@6.5.1 shipit << parameters.args >> $AUTO_ARGS
+          script: npx auto@${AUTO_VERSION:-<< parameters.version >>} shipit << parameters.args >> $AUTO_ARGS
 
   auto-pr-check:
     executor: node/build

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -145,7 +145,7 @@ jobs:
     parameters:
       version:
         type: string
-        default: 6.5.1
+        default: latest
       args:
         type: string
         default: ""

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.1.1
+# Orb Version 2.0.0
 
 version: 2.1
 description: Common yarn commands
@@ -152,16 +152,3 @@ jobs:
     steps:
       - run-release:
           script: npx auto@${AUTO_VERSION:-<< parameters.version >>} shipit << parameters.args >> $AUTO_ARGS
-
-  auto-pr-check:
-    executor: node/build
-    steps:
-      - setup
-      - run:
-          name: Check if PR has valid labels
-          command: |
-            if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
-              npx auto pr-check --pr $CIRCLE_PR_NUMBER --url $CIRCLE_PULL_REQUEST
-            else
-              npx auto pr-check --pr ${CIRCLE_PULL_REQUEST##https:/*/} --url $CIRCLE_PULL_REQUEST
-            fi


### PR DESCRIPTION
Make the auto version configurable either by updating the `version` parameter or the `AUTO_VERSION` env var. 

It defaults to `6.5.1`. 

cc @hipstersmoothie you might find this interesting. 
