### PR TITLE
Add orb docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CircleCI 2.1 introduces [several new features](https://github.com/CircleCI-Publi
 
 For more info on Orbs, checkout their [docs](https://github.com/CircleCI-Public/config-preview-sdk/tree/master/docs)!
 
-The TL;DR is that an `orb` yml configuration file that's used to share things like [executors](orb-executors), [commands](orb-commands), and [jobs](orb-jobs) across your CircleCi builds.
+(The TL;DR is there's an `orb` yml configuration file that's used to share things like [executors](orb-executors), [commands](orb-commands), and [jobs](orb-jobs) across your CircleCi builds.)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more info on Orbs, checkout their [docs](https://github.com/CircleCI-Public/
 
 ## Getting Started
 
-All our orbs are `.yml` files that are stored in `src/<orb-name>/<orb-name>.yml`. The nested directory is so that every orb can have associated documentation beside it.
+Orb files are stored in `src/<orb-name>/<orb-name>.yml`. The nested directory is so that every orb can have associated documentation beside it.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Orb files are stored in `src/<orb-name>/<orb-name>.yml`. The nested directory is
 
 ## Versioning
 
-Every orb has a comment like `# Orb Version 1.2.3` on the first line of the file. This comment is significant in that it's used to determine which version of the orb should be deployed (which will be discussed in the next section). Every orb in master will have a comment representing the currently deployed production version.
+Every orb has a comment like `# Orb Version 1.2.3` on the first line of the file. This comment is significant in that it's used to determine which version of the orb should be deployed (which will be discussed in the next section). Orbs in `master` will have a comment representing the currently deployed production version.
 
 When you make a change to an orb file you _must_ update the version. CI checks will fail otherwise.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ CircleCI 2.1 introduces [several new features](https://github.com/CircleCI-Publi
 
 For more info on Orbs, checkout their [docs](https://github.com/CircleCI-Public/config-preview-sdk/tree/master/docs)!
 
+The TL;DR is that an `orb` yml configuration file that's used to share things like [executors](orb-executors), [commands](orb-commands), and [jobs](orb-jobs) across your CircleCi builds.
+
+## Getting Started
+
+All our orbs are `.yml` files that are stored in `src/<orb-name>/<orb-name>.yml`. The nested directory is so that every orb can have associated documentation beside it.
+
+## Versioning
+
+Every orb has a comment like `# Orb Version 1.2.3` on the first line of the file. This comment is significant in that it's used to determine which version of the orb should be deployed (which will be discussed in the next section). Every orb in master will have a comment representing the currently deployed production version.
+
+When you make a change to an orb file you _must_ update the version. CI checks will fail otherwise.
+
 ## Deploying
 
-To deploy a change, increment the version located at the [top of the file](https://github.com/artsy/orbs/blob/master/src/yarn/yarn.yml#L1) and merge.
+There are two types of deployments that happen in this repo.
+
+1. Canary deployments that happen on every PR change
+2. Production deployments that happen when a PR is merged to master.
+
+When you make a change to an orb (and update the version) a canary version will be published. Check the build logs for the version name. This canary build can be used (before your PR is merged to master) to test orb changes in other projects. It's _highly_ recommended that you utilize this canary system to test changes that may impact many projects.
+
+Upon merging a PR, CI will publish the changed orbs to CircleCI's public registry. Artsy also has [renovate configuration](reno-config) to update orb changes across Artsy's GitHub org.
+
+The deployment process is driven by a set of bash scripts in the `scripts` directory. `publish_orbs.sh` is responsible for publishing both the canary and release version of the orbs. It's heavily commented and you're encouraged to read through it if you're interested in how the process works.
+
+[orb-executors]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
+[orb-commands]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
+[orb-jobs]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
+[reno-config]: https://github.com/artsy/renovate-config/blob/f8d47916b38096ebf834985e926253dcc0f78e25/lib/config-builder.js#L55-L62

--- a/src/hokusai/README.md
+++ b/src/hokusai/README.md
@@ -1,0 +1,5 @@
+# artsy/hokusai
+
+This orb is primarily built to share hokusai configuration across many CircleCI setups.
+
+The bulk of the current implementation contains the PR release process, but other capabilities may be added in the future. See [Force's CircleCI config](https://github.com/artsy/force/blob/75c48fc8a7739b213ddb711480ced66139d6949a/.circleci/config.yml) for an example of how to use it.

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -1,0 +1,25 @@
+# artsy/node
+
+This node contains shared [executors](orb-executors) to be used across our node projects.
+
+## Usage example
+
+To reuse the `build` executor
+
+```yaml
+# In your project's .circleci/config.yml
+
+# Using the volatile label is _not_ recommended.
+# Use the version in the comment at the top of node.yml instead.
+
+orbs:
+  node: artsy/node@volatile
+
+jobs:
+  build:
+    executors: node/build
+    steps:
+      # ... add steps here
+```
+
+[orb-executors]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors

--- a/src/yarn/README.md
+++ b/src/yarn/README.md
@@ -1,0 +1,3 @@
+# artsy/yarn
+
+This orb contains the bulk of Artsy's commonly used [yarn](https://yarnpkg.com/en/) commands that power the builds for our frontend and Node projects.


### PR DESCRIPTION
Resolves PLATFORM-1425

This includes docs around our orbs. I've still got to add details to the `yarn` orb readme.