### PR TITLE
Don't fail if orb created but not published

### DIFF
--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -17,8 +17,15 @@ get_orb_version() {
   echo $VERSION
 }
 
+is_orb_created() {
+  local CREATED=$(circleci orb list artsy | grep -w "artsy/$1")
+  if [ ! -z "$CREATED" ]; then
+    echo "true"
+  fi
+}
+
 is_orb_published() {
-  PUBLISHED=$(circleci orb info artsy/$1 > /dev/null 2>&1; echo $?)
+  local PUBLISHED=$(circleci orb info artsy/$1 > /dev/null 2>&1; echo $?)
   if [ "$PUBLISHED" -eq "0" ]; then
     echo "true"
   fi


### PR DESCRIPTION
The primary purpose of this PR is to fix cases where publishing an orb fails when the orb has been created but not yet fully published. 

See [this failure](https://circleci.com/gh/artsy/orbs/134).

To understand why this error happened, it requires a little bit of knowledge about both how CircleCI handles orb publishing and how our scripts check if an orb is published. 

With CircleCI you can either publish a development orb (which is tagged with any label) or a release version. 

For example, a dev version may look like

```
circleci orb publish ./src/yarn/yarn.yml artsy/yarn@dev:1.2.3
```

whereas a full version would be

```
circleci orb publish ./src/yarn/yarn.yml artsy/yarn@1.2.3
```

The only difference is the **dev:** label in the dev version. A side note, the label doesn't have to be dev and could technically be anything. 

So, currently we publish a canary version of an orb on every PR. If the orb is new, we create it first (which is a separate step that has to be done before publishing can happen). The error encounter here is caused by how we check if the orb has been previously created. We use the `circleci orb info` command.

```
circleci orb info artsy/yarn
```

When this command is ran, it'll tell you if the orb is published and what the latest version is. Unfortunately, if only a _dev_ version is published, the command passes with no result... which is counter to an assumption I made in the `is_orb_published` function. 

Anyway, I created a new function that uses the `circleci orb list` command which lists all _created_ orbs, even if no version is published. 

Also, one last thing: If the `SLACK_WEBHOOK` env var isn't present, I updated it to skip trying to send the message (so it didn't fail on projects not using slack). 