### PR TITLE
Remove hardcoded artsy namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             chmod +x ./slack
       - run:
           name: Publish orbs
-          command: scripts/publish_orbs.sh
+          command: NAMESPACE=artsy scripts/publish_orbs.sh
 
 workflows:
   build:

--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -2,6 +2,14 @@
 
 VERSION_REGEX="[0-9]\.[0-9]\.[0-9]"
 
+check_for_namespace() {
+  NAMESPACE=${NAMESPACE:-""}
+  if [ -z "$NAMESPACE" ]; then
+    echo "An env variable NAMESPACE must be provided that matches your CircleCI orb namespace"
+    exit 1
+  fi
+}
+
 get_orb_path() {
   local ORB="$1"
   local YML_PATH="./src/$ORB/$ORB.yml"
@@ -18,21 +26,24 @@ get_orb_version() {
 }
 
 is_orb_created() {
-  local CREATED=$(circleci orb list artsy | grep -w "artsy/$1")
+  check_for_namespace
+  local CREATED=$(circleci orb list $NAMESPACE | grep -w "$NAMESPACE/$1")
   if [ ! -z "$CREATED" ]; then
     echo "true"
   fi
 }
 
 is_orb_published() {
-  local PUBLISHED=$(circleci orb info artsy/$1 > /dev/null 2>&1; echo $?)
+  check_for_namespace
+  local PUBLISHED=$(circleci orb info $NAMESPACE/$1 > /dev/null 2>&1; echo $?)
   if [ "$PUBLISHED" -eq "0" ]; then
     echo "true"
   fi
 }
 
 get_published_orb_version() {
-  LAST_PUBLISHED=$(circleci orb info artsy/$1 | grep -i latest | grep -o "$VERSION_REGEX")
+  check_for_namespace
+  local LAST_PUBLISHED=$(circleci orb info $NAMESPACE/$1 | grep -i latest | grep -o "$VERSION_REGEX")
   echo $LAST_PUBLISHED
 }
 

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -14,9 +14,10 @@ set -euo pipefail
 . ./scripts/orb_utils.sh
 . ./scripts/colors.sh
 
+check_for_namespace
 
 echo ""
-echo "Beginning publish of artsy/$1 orb"
+echo "Beginning publish of $NAMESPACE/$1 orb"
 echo ""
 
 
@@ -51,7 +52,7 @@ BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 
 # Build the dev version prefix. When not on the master branch this will be
 # used to publish a dev version of the orb. That can be pulled in using
-# artsy/<orb-name>@dev:<version>. This is useful for testing purposes.
+# $NAMESPACE/<orb-name>@dev:<version>. This is useful for testing purposes.
 #
 # This will be referred to as "dev mode" in later comments
 DEV=""
@@ -96,23 +97,23 @@ if [ ! -z "$IS_PUBLISHED" ]; then
     "=")
       # When not in dev mode
       if [ -z "$DEV" ]; then
-        echo "artsy/$ORB@$VERSION is the latest, skipping publish"
+        echo "$NAMESPACE/$ORB@$VERSION is the latest, skipping publish"
         exit 0
       fi
       ;;
     "<")
-      echo $(RED "artsy/$ORB@$LAST_PUBLISHED is the latest, cannot publish older version $VERSION")
+      echo $(RED "$NAMESPACE/$ORB@$LAST_PUBLISHED is the latest, cannot publish older version $VERSION")
       echo $(RED "Please update $ORB_PATH to have a version greater than $LAST_PUBLISHED")
       exit 1
       ;;
     ">")
       # when not in dev mode
       if [ -z "$DEV" ]; then
-        echo "Preparing to bump artsy/$ORB from $LAST_PUBLISHED to $VERSION"
+        echo "Preparing to bump $NAMESPACE/$ORB from $LAST_PUBLISHED to $VERSION"
       fi
       ;;
     *)
-      echo $(RED "Version comparison for artsy/$ORB failed.")
+      echo $(RED "Version comparison for $NAMESPACE/$ORB failed.")
       echo $(RED "Current version: $VERSION")
       echo $(RED "Published version: $LAST_PUBLISHED")
       exit 1
@@ -121,21 +122,21 @@ if [ ! -z "$IS_PUBLISHED" ]; then
 
   # When in dev mode
   if [ ! -z "$DEV" ];then
-    echo "Preparing to publish dev orb artsy/$ORB@$FULL_VERSION"
+    echo "Preparing to publish dev orb $NAMESPACE/$ORB@$FULL_VERSION"
   fi
 
 elif [ -z "$IS_CREATED" ]; then
-  echo "Orb artsy/$ORB isn't in the registry. Creating its registry entry..."
-  circleci orb create artsy/$ORB $TOKEN --no-prompt
-  echo "Orb created, prepaing to publish artsy/$ORB@$FULL_VERSION"
+  echo "Orb $NAMESPACE/$ORB isn't in the registry. Creating its registry entry..."
+  circleci orb create $NAMESPACE/$ORB $TOKEN --no-prompt
+  echo "Orb created, prepaing to publish $NAMESPACE/$ORB@$FULL_VERSION"
 fi
 
 
 # Publish to CircleCI (when it's not a dry run)
 if [ -z "$DRY_RUN" ]; then
-  circleci orb publish $ORB_PATH artsy/$ORB@$FULL_VERSION $TOKEN
+  circleci orb publish $ORB_PATH $NAMESPACE/$ORB@$FULL_VERSION $TOKEN
 else
-  echo "$(YELLOW "[skipped]") circleci orb publish $ORB_PATH artsy/$ORB@$FULL_VERSION"
+  echo "$(YELLOW "[skipped]") circleci orb publish $ORB_PATH $NAMESPACE/$ORB@$FULL_VERSION"
 fi
 
 
@@ -144,7 +145,7 @@ if [ -z "$DRY_RUN" ] && [ -z "$DEV" ] && [ ! -z "$SLACK_WEBHOOK_URL" ]; then
   ./slack \
     -color "good" \
     -title "Circle CI $ORB orb v$VERSION published!" \
-    -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/artsy/orbs/tree/master}" \
+    -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/$NAMESPACE/orbs/tree/master}" \
     -user_name "artsyit" \
     -icon_emoji ":crystal_ball:"
 

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -60,11 +60,8 @@ if [ "$BRANCH" != "master" ]; then
   DEV="dev:"
   echo $(YELLOW "[Running in dev mode]")
 
-  # Build the version postfix which should be unique per PR
-  VERSION_POSTFIX=${CIRCLE_PULL_REQUEST##https:/*/}
-  if [ -z "$VERSION_POSTFIX" ]; then
-    VERSION_POSTFIX="$CIRCLE_SHA1"
-  fi
+  # Build the version postfix which should be unique per branch
+  VERSION_POSTFIX="$(echo "$BRANCH" | md5sum | awk '{ print $1 }')"
   VERSION_POSTFIX=".$VERSION_POSTFIX"
 fi
 

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 . ./scripts/orb_utils.sh
 
+check_for_namespace
+
 ORB="$1"
 echo ""
-echo "Validating artsy/$1 orb"
+echo "Validating $NAMESPACE/$1 orb"
 
 ORB_PATH=$(get_orb_path $ORB)
 
@@ -39,7 +41,7 @@ if [ ! -z "$IS_PUBLISHED" ]; then
     for file in ${ALL_CHANGES[@]}; do
       if [[ "$ORB_PATH" == *"$file" ]] && [[ "$VERSION" == "$PUBLISHED_VERSION" ]]; then
         echo ""
-        echo "artsy/$ORB has been updated since master but hasn't had its version bumped."
+        echo "$NAMESPACE/$ORB has been updated since master but hasn't had its version bumped."
         echo "Update its version in $ORB_PATH"
         exit 1
       fi

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.0
+# Orb Version 0.2.0
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy
@@ -24,6 +24,10 @@ commands:
 jobs:
   publish:
     executor: orb-scripts
+    parameters:
+      namespace:
+        description: CircleCI orb namespace
+        type: string
     steps:
       - checkout
       - run:
@@ -34,4 +38,4 @@ jobs:
             chmod +x ./slack
       - run:
           name: Publish orbs
-          command: scripts/publish_orbs.sh
+          command: NAMESPACE=<< parameters.namespace >> scripts/publish_orbs.sh


### PR DESCRIPTION
Our orb scripts have been hard coded to Artsy's namespace. I'm working to make our orb publishing setup sharable and this is one of the big steps required to make that happen.

I included an unrelated change to make the canary orb publishes more stable. Before the version would change depending on whether or not circleci had a PR number. Now I just made the version a hash based off of the branch (so it's always the same, regardless if it's just a branch build or a PR build). This'll just make it easier to test with canaries. 