### PR TITLE
Don't publish a dev orb that hasn't changed

### DIFF
--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -25,6 +25,18 @@ get_orb_version() {
   echo $VERSION
 }
 
+is_orb_changed() {
+    check_for_namespace
+
+    local ORB="$1"
+    local ORB_PATH="$(get_orb_path $ORB)"
+    local CHANGED="$(git diff --name-only master $ORB_PATH)"
+
+    if [ ! -z "$CHANGED" ]; then
+      echo "true"
+    fi
+}
+
 is_orb_created() {
   check_for_namespace
   local CREATED=$(circleci orb list $NAMESPACE | grep -w "$NAMESPACE/$1")


### PR DESCRIPTION
Closes #40.

When I set up the canary image deployment process, I did it pretty naively. It always published, regardless of whether or not there were changes. This was a little wasteful, so I added a check to ensure the publish only happened when changes were made. 

I also made it a little easier to parse through the logs to see which lines were related to which deployment process by adding a header and footer to each deploy. 