### PR TITLE
Ensure scripts are available from docker image

### DIFF
--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -30,7 +30,7 @@ is_orb_changed() {
 
     local ORB="$1"
     local ORB_PATH="$(get_orb_path $ORB)"
-    local CHANGED="$(git diff --name-only master $ORB_PATH)"
+    local CHANGED="$(git diff --name-only origin/master $ORB_PATH)"
 
     if [ ! -z "$CHANGED" ]; then
       echo "true"

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.2.0
+# Orb Version 0.2.1
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy
@@ -13,7 +13,10 @@ commands:
     steps:
       - run:
           name: Set orb scripts path
-          command: [ ! -d "./scripts" ] && ln -s /orb-scripts scripts
+          command: |
+            if [ ! -d "./scripts" ]; then 
+              ln -s /orb-scripts scripts
+            fi
 
 jobs:
   publish:


### PR DESCRIPTION
I'd accidentally committed part of this to master (which didn't matter really because it failed config validation). 

The docker image was dumping things in the working directory, but Circle changes the working directory. Instead I'm dumping them in `/orb-scripts` and doing a sym-link if the local scripts directory isn't present. This should cover both the local case of running the scripts and the docker case where they're copied to the root directory. 