### PR TITLE
Put scripts in writable directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM circleci/circleci-cli
-ADD ./scripts /orb-scripts
+COPY ./scripts /tmp/orb-scripts

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.2.1
+# Orb Version 0.2.2
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy
@@ -15,7 +15,7 @@ commands:
           name: Set orb scripts path
           command: |
             if [ ! -d "./scripts" ]; then 
-              ln -s /orb-scripts scripts
+              ln -s /tmp/orb-scripts scripts
             fi
 
 jobs:


### PR DESCRIPTION
I'm working on https://github.com/auto-it/orbs/pull/2 to try getting auto onto artsy's orb publishing setup, but for whatever reason the files weren't where I expected them to be. I have a hunch that it was a permissions issue, so I've changed the copy to be in the `/tmp` directory (which is writable). 