### PR TITLE
Use smaller alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
-FROM circleci/circleci-cli:0.1.5691
+FROM circleci/circleci-cli:0.1.5691-alpine
 COPY ./scripts /tmp/orb-scripts
+RUN apk add --no-cache bash git


### PR DESCRIPTION
Instead of using the full sized circleci-cli image, use the smaller (hopefully faster) alpine version. 