### PR TITLE
Add auto orb to release process

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -6,7 +6,7 @@ description: Common yarn commands
 orbs:
   node: artsy/node@0.1.0
   queue: eddiewebb/queue@1.0.110
-  auto: auto/release@0.0.1
+  auto: auto/release@0.0.2
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -6,7 +6,7 @@ description: Common yarn commands
 orbs:
   node: artsy/node@0.1.0
   queue: eddiewebb/queue@1.0.110
-  auto: auto/release@0.0.2
+  auto: auto/release@0.0.3
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -6,7 +6,7 @@ description: Common yarn commands
 orbs:
   node: artsy/node@0.1.0
   queue: eddiewebb/queue@1.0.110
-  auto: auto/release@0.0.4
+  auto: auto/release@0.0.5
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 2.0.0
+# Orb Version 2.1.0
 
 version: 2.1
 description: Common yarn commands
@@ -6,6 +6,7 @@ description: Common yarn commands
 orbs:
   node: artsy/node@0.1.0
   queue: eddiewebb/queue@1.0.110
+  auto: auto/release@0.0.1
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching
@@ -56,16 +57,20 @@ commands:
       - setup
       - run: yarn << parameters.script >>
 
+  pre-release:
+    steps:
+      - setup
+      - run: git pull
+      # Setup the .npmrc with the proper registry and auth token to publish
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+
   run-release:
     parameters:
       script:
         type: string
         default: yarn release
     steps:
-      - setup
-      - run: git pull
-      # Setup the .npmrc with the proper registry and auth token to publish
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - pre-release
       - run: << parameters.script >>
 
 jobs:
@@ -150,5 +155,5 @@ jobs:
         type: string
         default: ""
     steps:
-      - run-release:
-          script: npx auto@${AUTO_VERSION:-<< parameters.version >>} shipit << parameters.args >> $AUTO_ARGS
+      - pre-release
+      - auto/shipit

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -62,7 +62,9 @@ commands:
       - setup
       - run: git pull
       # Setup the .npmrc with the proper registry and auth token to publish
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: Setup npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
   run-release:
     parameters:

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -6,7 +6,7 @@ description: Common yarn commands
 orbs:
   node: artsy/node@0.1.0
   queue: eddiewebb/queue@1.0.110
-  auto: auto/release@0.0.3
+  auto: auto/release@0.0.4
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching


### PR DESCRIPTION
This updates our `auto release` process to use the open source `auto` orb found [here](https://github.com/auto-it/orbs/blob/master/src/release/release.yml).

It's different than the setup we originally had largely because it relies on the `auto` binary. This makes it portable across other, potentially non-node projects. 

The orb is currently external to be used in collaboration with the team behind auto to move to supporting more release types, _but_ it can always be copied back over into artsy's repo at any point if needed.

I'm an admin to the other repo so I can add other contributors, but generally the orb _shouldn't_ change much beyond where it's at now. 

https://github.com/artsy/renovate-config is using this version of the orb currently. 