### PR TITLE
Bind orb-scripts to latest docker hub tag

### DIFF
--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.2.2
+# Orb Version 0.2.3
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -6,7 +6,7 @@ description: A simple set of tools for managing orbs by Artsy
 executors:
   orb-scripts:
     docker:
-      - image: artsy/orb-scripts
+      - image: artsy/orb-scripts@latest
 
 commands:
   setup-paths:


### PR DESCRIPTION
There was an issue in the `auto/release` orb where it wasn't pulling the right docker hub version. I'm trying to explicitly add the latest tag in hopes that that forces it to update. 