### PR TITLE
Remove invalid syntax for orb-scripts executor

### DIFF
--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -6,7 +6,7 @@ description: A simple set of tools for managing orbs by Artsy
 executors:
   orb-scripts:
     docker:
-      - image: artsy/orb-scripts@latest
+      - image: artsy/orb-scripts
 
 commands:
   setup-paths:

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.2.3
+# Orb Version 0.2.4
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy


### PR DESCRIPTION
I thought this would pin it to the latest version, but it doesn't actually do that. It's actually not valid from the docker perspective cause it's getting treated as part of the name.

Oops. 