### PR TITLE
iam-auth for hokusai Orb #PLATFORM-1478

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM circleci/circleci-cli:0.1.5691-alpine
 COPY ./scripts /tmp/orb-scripts
-RUN apk add --no-cache bash git
+RUN apk add --no-cache bash git curl

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:head
+      - image: artsy/hokusai:0.5
 
 commands:
   setup:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.3.1
+# Orb Version 0.4.0
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.3.0
+# Orb Version 0.3.1
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5
+      - image: artsy/hokusai:head
 
 commands:
   setup:
@@ -109,5 +109,5 @@ jobs:
           command: hokusai pipeline gitlog | grep migration || true
       - run:
           name: Deploy
-          command: hokusai production deploy staging --update-config
+          command: hokusai pipeline promote --update-config
           no_output_timeout: << parameters.time-out >>

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -48,8 +48,11 @@ jobs:
     steps:
       - setup
       - run:
+          name: Install AWS IAM Authenticator
+          command: curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && chmod +x ./aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
+      - run:
           name: Configure
-          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
+          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config-ci --platform linux
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai staging update --skip-checks --dry-run
@@ -71,8 +74,11 @@ jobs:
     steps:
       - setup
       - run:
+          name: Install AWS IAM Authenticator
+          command: curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && chmod +x ./aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
+      - run:
           name: Configure
-          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
+          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config-ci --platform linux
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai production update --skip-checks --dry-run

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -25,10 +25,12 @@ commands:
         type: string
         default: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_linux_amd64"
     steps:
-      - run: |
-        curl -L -o aws-iam-authenticator << parameters.uri >>
-        chmod +x ./aws-iam-authenticator
-        mv aws-iam-authenticator /usr/local/bin/
+      - run:
+          name: Install AWS IAM Authenticator
+          command: |
+            curl -L -o aws-iam-authenticator << parameters.uri >>
+            chmod +x ./aws-iam-authenticator
+            mv aws-iam-authenticator /usr/local/bin/
 
   configure-hokusai:
     parameters:
@@ -36,10 +38,12 @@ commands:
         type: string
         default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml"
     steps:
-      - run: |
-        mkdir -p ~/.hokusai
-        curl -o ~/.hokusai/config.yml << parameters.configUri >>
-        hokusai configure
+      - run:
+          name: Configure Hokusai
+          command: |
+            mkdir -p ~/.hokusai
+            curl -o ~/.hokusai/config.yml << parameters.configUri >>
+            hokusai configure
 
 
 jobs:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -19,6 +19,29 @@ commands:
       - setup
       - setup_remote_docker
 
+  install-aws-iam-authenticator:
+    parameters:
+      uri:
+        type: string
+        default: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_linux_amd64"
+    steps:
+      - run: |
+        curl -L -o aws-iam-authenticator << parameters.uri >>
+        chmod +x ./aws-iam-authenticator
+        mv aws-iam-authenticator /usr/local/bin/
+
+  configure-hokusai:
+    parameters:
+      configUri:
+        type: string
+        default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml"
+    steps:
+      - run: |
+        mkdir -p ~/.hokusai
+        curl -o ~/.hokusai/config.yml << parameters.configUri >>
+        hokusai configure
+
+
 jobs:
   test:
     executor: deploy
@@ -47,12 +70,8 @@ jobs:
         default: 20m
     steps:
       - setup
-      - run:
-          name: Install AWS IAM Authenticator
-          command: curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && chmod +x ./aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
-      - run:
-          name: Configure
-          command: mkdir ~/.hokusai && curl -o ~/.hokusai/config.yml https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml && hokusai configure
+      - install-aws-iam-authenticator
+      - configure-hokusai
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai staging update --skip-checks --dry-run
@@ -73,12 +92,8 @@ jobs:
         default: 20m
     steps:
       - setup
-      - run:
-          name: Install AWS IAM Authenticator
-          command: curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && chmod +x ./aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
-      - run:
-          name: Configure
-          command: mkdir ~/.hokusai && curl -o ~/.hokusai/config.yml https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml && hokusai configure
+      - install-aws-iam-authenticator
+      - configure-hokusai
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai production update --skip-checks --dry-run

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -52,7 +52,7 @@ jobs:
           command: curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && chmod +x ./aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
       - run:
           name: Configure
-          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config-ci --platform linux
+          command: mkdir ~/.hokusai && curl -o ~/.hokusai/config.yml https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml && hokusai configure
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai staging update --skip-checks --dry-run
@@ -78,7 +78,7 @@ jobs:
           command: curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator && chmod +x ./aws-iam-authenticator && mv aws-iam-authenticator /usr/local/bin/
       - run:
           name: Configure
-          command: hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config-ci --platform linux
+          command: mkdir ~/.hokusai && curl -o ~/.hokusai/config.yml https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml && hokusai configure
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai production update --skip-checks --dry-run


### PR DESCRIPTION
Install the kubernetes iam authenticator and use kubectl config-ci config file

Now that the IAM role in https://github.com/artsy/infrastructure/pull/159 and the mapped Kubernetes RBAC role in https://github.com/artsy/substance/pull/135 have been created we can use the config file that assumes this role in `s3://artsy-citadel/k8s/config-ci`