### PR TITLE
Validate orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,14 @@ executors:
       - image: circleci/circleci-cli
 
 jobs:
+  validate_orbs:
+    executor: cli
+    steps:
+      - checkout
+      - run:
+          name: Validate orbs
+          command: NAMESPACE=artsy scripts/validate_orbs.sh
+
   publish_orbs:
     executor: cli
     steps:
@@ -23,5 +31,8 @@ jobs:
 workflows:
   build:
     jobs:
+      - validate_orbs
       - publish_orbs:
           context: circleci-api
+          requires:
+            - validate_orbs

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -19,6 +19,7 @@ fi
 VERSION=$(get_orb_version $ORB)
 VERSION_COMMENT=$(head -n 1 $ORB_PATH)
 IS_PUBLISHED=$(is_orb_published $ORB)
+IS_CREATED=$(is_orb_created $ORB)
 
 # Ensure the version is defined and that the version comment actually is a comment...
 if [ -z $VERSION ] || [ ! "${VERSION_COMMENT:0:1}" == "#" ]; then
@@ -29,7 +30,7 @@ if [ -z $VERSION ] || [ ! "${VERSION_COMMENT:0:1}" == "#" ]; then
   return
 fi
 
-if [ ! -z "$IS_PUBLISHED" ]; then
+if [ ! -z "$IS_CREATED" ] && [ ! -z "$IS_PUBLISHED" ]; then
 
   PUBLISHED_VERSION=$(get_published_orb_version $ORB)
   BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
I have a validation script that would ensure the orb version was bumped, but it got dropped. Publish orb does some level of validation so it was a little duplicative, but I'm adding it back for the version check part. 

We could probably optimize it better later, but this works for now. 