### PR TITLE
Simplify orb dev validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,10 @@ jobs:
 workflows:
   build:
     jobs:
-      - validate_orbs
+      - validate_orbs:
+          filters:
+            branches:
+              ignore:
+                - master
       - publish_orbs:
           context: circleci-api
-          requires:
-            - validate_orbs

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -80,14 +80,13 @@ if [ ! -z "$DEV" ]; then
   echo "This will be a dev deployment (prefixed with dev:)"
 fi
 
-
-# Ensure the orb is valid
-./scripts/validate_orb.sh $ORB
-
 ORB_PATH=$(get_orb_path $ORB)
 VERSION=$(get_orb_version $ORB)
 IS_PUBLISHED=$(is_orb_published $ORB)
 IS_CREATED=$(is_orb_created $ORB)
+
+# Ensure the orb is valid
+circleci orb validate $ORB_PATH
 
 if [ ! -z "$DEV" ]; then
   FULL_VERSION="$DEV$VERSION_POSTFIX"

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -71,7 +71,7 @@ if [ "$BRANCH" != "master" ]; then
 
   # Build the version postfix which should be unique per branch
   VERSION_POSTFIX="$(echo "$BRANCH" | md5sum | awk '{ print $1 }')"
-  VERSION_POSTFIX=".$VERSION_POSTFIX"
+  VERSION_POSTFIX="$VERSION_POSTFIX"
 fi
 
 # When in dev mode
@@ -90,7 +90,7 @@ IS_PUBLISHED=$(is_orb_published $ORB)
 IS_CREATED=$(is_orb_created $ORB)
 
 if [ ! -z "$DEV" ]; then
-  FULL_VERSION="$DEV$VERSION$VERSION_POSTFIX"
+  FULL_VERSION="$DEV$VERSION_POSTFIX"
 else
   FULL_VERSION="$VERSION"
 fi

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -19,6 +19,18 @@ commands:
             fi
 
 jobs:
+  validate:
+    executor: orb-scripts
+    parameters:
+      namespace:
+        description: CircleCI orb namespace
+        type: string
+    steps:
+      - checkout
+      - setup-paths
+      - run:
+          name: Validate orbs
+          command: NAMESPACE=<< parameters.namespace >> scripts/validate_orbs.sh
   publish:
     executor: orb-scripts
     parameters:

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.2.4
+# Orb Version 0.3.0
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy


### PR DESCRIPTION
This does two things:

1. Separates validate and publish so that the canary publish step isn't blocked by version validation issues
2. Changes the dev version format from `orb@dev:0.0.0.hash` to `orb@dev:hash`. This will ensure the canary version stays the same for that branch even if the version changes