### PR TITLE
Move pushing image to a command

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -45,6 +45,12 @@ commands:
             curl -o ~/.hokusai/config.yml << parameters.configUri >>
             hokusai configure
 
+  push-image:
+    steps:
+      - setup-docker
+      - run:
+          name: Push
+          command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
 
 jobs:
   test:
@@ -57,10 +63,7 @@ jobs:
   push:
     executor: deploy
     steps:
-      - setup-docker
-      - run:
-          name: Push
-          command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
+      - push-image
 
   deploy-staging:
     executor: deploy


### PR DESCRIPTION
More context in https://github.com/artsy/volt/pull/3745. We would like to move the pushing image steps to an orb _command_ so clients can use it in `pre-steps`.

We would get a [build error](https://circleci.com/gh/artsy/volt/8502) when using a _job_ in `pre-steps`.

![Screen Shot 2019-07-17 at 9 53 12 PM](https://user-images.githubusercontent.com/796573/61423351-796df980-a8dd-11e9-9407-325c4a88374a.png)
