### PR TITLE
Skip WIP CI orb #FF

### DIFF
--- a/src/skip-wip-ci/README.md
+++ b/src/skip-wip-ci/README.md
@@ -1,0 +1,28 @@
+# artsy/skip-wip-ci
+
+This node contains shared commands and jobs that hit Github's API and skips draft PRs or PRs with "wip", "skip ci", or "ci skip" in title.
+
+## Usage example
+
+To use the `skip-wip-ci` job
+
+```yaml
+# In your project's .circleci/config.yml
+
+# Using the volatile label is _not_ recommended.
+# Use the version in the comment at the top of node.yml instead.
+
+orbs:
+  skip-wip-ci: artsy/skip-wip-ci@volatile
+
+workflows:
+  default:
+    jobs:
+      - skip-wip-ci/skip-wip-ci
+      - test:
+          <<: *not_staging_release
+          requires:
+        - skip-wip-ci/skip-wip-ci
+```
+
+[orb-executors]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors

--- a/src/skip-wip-ci/skip-wip-ci.yml
+++ b/src/skip-wip-ci/skip-wip-ci.yml
@@ -1,0 +1,62 @@
+# Orb Version 0.1.0
+
+version: 2.1
+description: 'Use to skip CI when PR title contains "wip", "skip ci", "ci skip" or is draft'
+
+commands:
+  check-skippable-pr:
+    steps:
+      - run:
+          shell: /bin/bash
+          name: Check Skippable PR
+          command: |
+            required_env_vars=(
+              "BUNDLE_GITHUB__COM"
+              "CIRCLE_PROJECT_USERNAME"
+              "CIRCLE_PR_REPONAME"
+              "CIRCLE_PR_NUMBER"
+            )
+
+            for required_env_var in ${required_env_vars[@]}; do
+              if [[ -z "${!required_env_var}" ]]; then
+                printf "${required_env_var} not provided, but that doesn't mean we should skip CI.\n"
+                exit 0
+              fi
+            done
+
+            # Since we're piggybacking off of an existing OAuth var, tweak the var for our uses
+            token=$(printf "${BUNDLE_GITHUB__COM}" | cut -d':' -f1)
+
+            headers="Authorization: token $token"
+            api_endpoint="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PR_REPONAME}/pulls/${CIRCLE_PR_NUMBER}"
+
+            # Fetch PR metadata from Github's API and parse fields from json
+            github_res=$(curl --silent --header "${headers}" "${api_endpoint}" | jq '{mergeable_state: .mergeable_state, title: .title}')
+            mergeable_state=$(printf "${github_res}" | jq '.mergeable_state')
+            title=$(printf "${github_res}" | jq '.title' | tr '[:upper:]' '[:lower:]')
+            echo "${title}"
+
+            if [[ "${title}" == "null" && "${mergeable_state}" == "null" ]]; then
+              printf "Couldn't fetch info on PR, but that doesn't mean we should skip CI.\n"
+              exit 0
+            fi
+
+            if [[ "${mergeable_state}" == "\"draft\"" ]]; then
+              printf "PR is a draft, skipping CI!\n"
+              exit 1
+            fi
+
+            for skip_token in 'skip ci' 'ci skip' 'wip'; do
+              if [[ ${title} == *"${skip_token}"* ]]; then
+                printf "Found \"${skip_token}\" in PR title, skipping CI!\n"
+                exit 1
+              fi
+            done
+            exit 0
+
+jobs:
+  skip-wip-ci:
+    docker:
+      - image: alpine:3.7
+    steps:
+      - check-skippable-pr


### PR DESCRIPTION
This is an orb that has been abstracted from this PR: https://github.com/artsy/volt/pull/3796

Skips CI for PRs
- that are draft PRs
- that contain "skip ci", "ci skip", or "wip" in the title

Note: I have no idea how to test this and really Circle doesn't either (https://circleci.com/docs/2.0/testing-orbs/). It suggests publishing to a dev namespace and testing from there.