### PR TITLE
Bump orb version

### DIFF
--- a/src/skip-wip-ci/skip-wip-ci.yml
+++ b/src/skip-wip-ci/skip-wip-ci.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.1
+# Orb Version 0.2.0
 
 version: 2.1
 description: 'Use to skip CI when PR title contains "[wip]", "[skip ci]", "[ci skip]" or is draft'


### PR DESCRIPTION
Last orb PR merged but was not published, most likely due to PR name. Use this PR to publish the orb and bump version.