### PR TITLE
Pin auto to last version with binaries

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 2.1.0
+# Orb Version 2.1.1
 
 version: 2.1
 description: Common yarn commands

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -149,6 +149,8 @@ jobs:
 
   auto-release:
     executor: node/build
+    environment:
+      AUTO_VERSION: v7.6.0
     parameters:
       version:
         type: string


### PR DESCRIPTION
@mzikherman pointed out that v7.6.1 of auto has a release without binaries which broke our release process because we auto upgrade. I've pinned the version to v7.6.0. It'd be nice to think about a sort of gated automatic release process that only updates across the board once the update has successfully ran in an isolated project...

Worth noting that auto is controlled by [auto-it/orbs](https://github.com/auto-it/orbs/blob/master/src/release/release.yml) project. In our project, we can just configure that via environment variables. 

cc @hipstersmoothie