### PR TITLE
Fall back to circle builds if aws keys unavailable

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -40,8 +40,8 @@ commands:
                 exit 0
               fi
             else
-              printf "Required environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` unavailable. Exiting.\n"
-              exit 1
+              printf "Required environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` unavailable. Reverting back to Circle CI docker.\n"
+              exit 0
             fi
 
   build-image-via-artsy:

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.0
+# Orb Version 0.1.1
 
 version: 2.1
 description: >


### PR DESCRIPTION
Small change to allow forked PRs on Force to build without secure keys-- exit 0 if AWS keys are missing, and build with Circle as fallback.

Pair session with @izakp 

Related to https://artsyproduct.atlassian.net/browse/PLATFORM-2135