### PR TITLE
Remove extra setup step, add flags option

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -68,7 +68,6 @@ commands:
         default: ""
         description: Optional hokusai flags
     steps:
-      - setup-docker
       - run:
           name: Test
           command: hokusai test -f << parameters.filename >> << parameters.flags >>
@@ -86,6 +85,7 @@ jobs:
         default: ""
         description: Optional hokusai flags
     steps:
+      - setup-docker
       - run-tests:
           filename: << parameters.filename >>
           flags: << parameters.filename >>

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.7.1
+# Orb Version 0.7.2
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments
@@ -63,11 +63,15 @@ commands:
         type: string
         default: ./hokusai/test.yml
         description: The docker-compose yaml file to use
+      flags:
+        type: string
+        default: ""
+        description: Optional hokusai flags
     steps:
       - setup-docker
       - run:
           name: Test
-          command: hokusai test -f << parameters.filename >>
+          command: hokusai test -f << parameters.filename >> << parameters.flags >>
 
 jobs:
   test:
@@ -77,9 +81,14 @@ jobs:
         type: string
         default: ./hokusai/test.yml
         description: The docker-compose yaml file to use
+      flags:
+        type: string
+        default: ""
+        description: Optional hokusai flags
     steps:
-      - setup-docker
-      - run-tests
+      - run-tests:
+          filename: << parameters.filename >>
+          flags: << parameters.filename >>
 
   push:
     executor: deploy


### PR DESCRIPTION
Automated updates to the orb have [failed](https://github.com/artsy/diffusion/pull/177) because of an extra `setup-docker` step on the `hokusai/test` job. This removes the extra step, and adds the ability to pass hokusai flags to the test command. 

Confirmed that test job runs as expected here: https://github.com/artsy/positron/pull/2494
Confirmed that test command runs with flags as expected here: https://circleci.com/gh/artsy/force/36949