### PR TITLE
Separate out auto and add canary job

### DIFF
--- a/src/auto/README.md
+++ b/src/auto/README.md
@@ -1,0 +1,5 @@
+# artsy/auto
+
+This orb controls Artsy's package deployment process. It builds off of [a simple community orb](https://github.com/auto-it/orbs/blob/master/src/release/release.yml) that's itself a simple wrapper for [intuit's auto](https://github.com/intuit/auto).
+
+If your making a generic change about how `auto` executes, I recommend you do that [upstream](https://github.com/auto-it/orbs/blob/master/src/release/release.yml). If you're actually changing something specific to how Artsy deploys, then this is the right place for it.

--- a/src/auto/README.md
+++ b/src/auto/README.md
@@ -2,4 +2,4 @@
 
 This orb controls Artsy's package deployment process. It builds off of [a simple community orb](https://github.com/auto-it/orbs/blob/master/src/release/release.yml) that's itself a simple wrapper for [intuit's auto](https://github.com/intuit/auto).
 
-If your making a generic change about how `auto` executes, it's recommend you do that [upstream](https://github.com/auto-it/orbs/blob/master/src/release/release.yml). If you're actually changing something specific to how Artsy deploys, then this is the right place for it.
+If you're making a generic change about how `auto` executes, it's recommended you do that [upstream](https://github.com/auto-it/orbs/blob/master/src/release/release.yml). If you're actually changing something specific to how Artsy deploys, then this is the right place for it.

--- a/src/auto/README.md
+++ b/src/auto/README.md
@@ -2,4 +2,4 @@
 
 This orb controls Artsy's package deployment process. It builds off of [a simple community orb](https://github.com/auto-it/orbs/blob/master/src/release/release.yml) that's itself a simple wrapper for [intuit's auto](https://github.com/intuit/auto).
 
-If your making a generic change about how `auto` executes, I recommend you do that [upstream](https://github.com/auto-it/orbs/blob/master/src/release/release.yml). If you're actually changing something specific to how Artsy deploys, then this is the right place for it.
+If your making a generic change about how `auto` executes, it's recommend you do that [upstream](https://github.com/auto-it/orbs/blob/master/src/release/release.yml). If you're actually changing something specific to how Artsy deploys, then this is the right place for it.

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -4,12 +4,13 @@ version: 2.1
 description: An orb for working w/ intuit's auto
 
 orbs:
-  yarn: artsy/yarn@4.0.0
+  yarn: artsy/yarn@3.0.0
   node: artsy/node@0.1.0
   auto: auto/release@0.1.0
 
 jobs:
-  publish:
+  # Publishes a package to NPM
+  package:
     executor: node/build
     environment:
       AUTO_VERSION: v9.10.5
@@ -24,7 +25,8 @@ jobs:
       - yarn/pre-release
       - auto/shipit
 
-  publish-canary:
+  # Publishes a canary package to npm
+  canary:
     executor: node/build
     environment:
       AUTO_VERSION: v9.10.5

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,7 +1,7 @@
 # Orb Version 1.0.0
 
 version: 2.1
-description: An orb for working w/ intuit's auto
+description: Publish NPM packages and canary deployments with Intuit's Auto
 
 orbs:
   yarn: artsy/yarn@dev:94201cf9cd41b8b0d7441b5095ea044d

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -39,4 +39,4 @@ jobs:
         default: ""
     steps:
       - yarn/pre-release
-      - auto/shipit
+      - auto/canary

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -4,7 +4,7 @@ version: 2.1
 description: An orb for working w/ intuit's auto
 
 orbs:
-  yarn: artsy/yarn@3.0.0
+  yarn: artsy/yarn@dev:94201cf9cd41b8b0d7441b5095ea044d
   node: artsy/node@0.1.0
   auto: auto/release@0.1.0
 

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -10,7 +10,7 @@ orbs:
 
 jobs:
   # Publishes a package to NPM
-  package:
+  publish:
     executor: node/build
     environment:
       AUTO_VERSION: v9.10.5
@@ -26,7 +26,7 @@ jobs:
       - auto/shipit
 
   # Publishes a canary package to npm
-  canary:
+  publish-canary:
     executor: node/build
     environment:
       AUTO_VERSION: v9.10.5

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,0 +1,40 @@
+# Orb Version 1.0.0
+
+version: 2.1
+description: An orb for working w/ intuit's auto
+
+orbs:
+  yarn: artsy/yarn@4.0.0
+  node: artsy/node@0.1.0
+  auto: auto/release@0.1.0
+
+jobs:
+  publish:
+    executor: node/build
+    environment:
+      AUTO_VERSION: v9.10.5
+    parameters:
+      version:
+        type: string
+        default: v9.10.5
+      args:
+        type: string
+        default: ""
+    steps:
+      - yarn/pre-release
+      - auto/shipit
+
+  publish-canary:
+    executor: node/build
+    environment:
+      AUTO_VERSION: v9.10.5
+    parameters:
+      version:
+        type: string
+        default: v9.10.5
+      args:
+        type: string
+        default: ""
+    steps:
+      - yarn/pre-release
+      - auto/shipit

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 3.0.0
+# Orb Version 4.0.0
 
 version: 2.1
 description: Common yarn commands
@@ -6,7 +6,6 @@ description: Common yarn commands
 orbs:
   node: artsy/node@0.1.0
   queue: eddiewebb/queue@1.0.110
-  auto: auto/release@0.0.5
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching
@@ -146,18 +145,3 @@ jobs:
     executor: node/build
     steps:
       - run-release
-
-  auto-release:
-    executor: node/build
-    environment:
-      AUTO_VERSION: v9.10.5
-    parameters:
-      version:
-        type: string
-        default: v9.10.5
-      args:
-        type: string
-        default: ""
-    steps:
-      - pre-release
-      - auto/shipit

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -59,7 +59,6 @@ commands:
   pre-release:
     steps:
       - setup
-      - run: git pull
       # Setup the .npmrc with the proper registry and auth token to publish
       - run:
           name: Setup npmrc


### PR DESCRIPTION
Fixes #85 

**NOTICE: BREAKING CHANGE**

_Merging this PR will generate noise, but it should also reduce future noise for  non-auto related projects that also use the yarn orb_

---

This PR does two things:

1. Breaks out all  `auto` related stuff into a separate orb to hopefully reduce the amount of noise experienced by our node services
2. Adds a `canary` job that we can use to publish WIP packages for reaction, palette, etc to make it easier for us to test changes in review apps and the like. 

You can see the usage in https://github.com/artsy/reaction/pull/3168