### PR TITLE
Update yarn version in auto orb to the latest

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,10 +1,10 @@
-# Orb Version 1.0.0
+# Orb Version 1.0.1
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto
 
 orbs:
-  yarn: artsy/yarn@dev:94201cf9cd41b8b0d7441b5095ea044d
+  yarn: artsy/yarn@4.0.0
   node: artsy/node@0.1.0
   auto: auto/release@0.1.0
 


### PR DESCRIPTION
cc @eessex 

This is just a follow up to remove the canary version of the yarn orb from the auto orb. 