### PR TITLE
Fix jest test results path, save artifacts for later use

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 4.0.1
+# Orb Version 4.0.2
 
 version: 2.1
 description: Common yarn commands
@@ -123,7 +123,9 @@ jobs:
       - run-script:
           script: jest --reporters=default --reporters=jest-junit << parameters.args >>
       - store_test_results:
-          path: reports
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
 
   update-cache:
     executor: node/build


### PR DESCRIPTION
I noticed the test results _still_ weren't being stored. CircleCI links to [this tutorial](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint/) which showed the missing piece of the puzzle.

```
- store_test_results:
          path: reports/junit
```

specifically you had to drill down into the junit folder instead of just giving it the top level. 