### PR TITLE
Update version of auto

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -29,11 +29,11 @@ jobs:
   publish-canary:
     executor: node/build
     environment:
-      AUTO_VERSION: v9.10.5
+      AUTO_VERSION: v9.15.4
     parameters:
       version:
         type: string
-        default: v9.10.5
+        default: v9.15.4
       args:
         type: string
         default: ""

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.0.1
+# Orb Version 1.0.2
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto


### PR DESCRIPTION
This update contains a change to canaries to _not_ release a canary when a PR would not otherwise generate a release. It'll be good for reducing overall noise. 