### PR TITLE
Don't try to release canary unless on a non-fork PR build

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.0.2
+# Orb Version 1.1.0
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -38,5 +38,17 @@ jobs:
         type: string
         default: ""
     steps:
+      - run:
+          name: Don't deploy canary if it's not a PR or if it's a fork
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "Skipping, only deploys canaries on PR builds"
+              circleci-agent step halt
+            fi
+
+            if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
+              echo "Skipping, can't deploy canaries for forks due to permissions issues."
+              circleci-agent step halt
+            fi
       - yarn/pre-release
       - auto/canary


### PR DESCRIPTION
There have been some [CI failures](https://app.circleci.com/jobs/github/artsy/lint-changed/76/parallel-runs/0/steps/0-109) for the `publish-canary` job that happen when a branch is pushed and CI starts for it but a PR has not yet been created. 

This adds a short circuit for cases (like when the PR hasn't been created) to avoid failing in those circumstances. Instead it prints out a debug message and skips the rest of the step. 