### PR TITLE
Add commit hooks for easier development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For more info on Orbs, checkout their [docs](https://github.com/CircleCI-Public/
 
 Orb files are stored in `src/<orb-name>/<orb-name>.yml`. The nested directory is so that every orb can have associated documentation beside it.
 
+To make it easier to perform changes locally, it's recommended that you run `setup.sh` in the root. This will setup the tools you need to be able to run circle commands locally along with some helpful pre-commit hooks.
+
 ## Versioning
 
 Every orb has a comment like `# Orb Version 1.2.3` on the first line of the file. This comment is significant in that it's used to determine which version of the orb should be deployed (which will be discussed in the next section). Orbs in `master` will have a comment representing the currently deployed production version.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,21 @@
+# For more information on configuring lefthook, see the guide:
+# https://github.com/Arkweid/lefthook/blob/master/docs/full_guide.md
+
+pre-commit:
+  parallel: true
+  commands:
+    validate-orbs:
+      glob: "src/**/*.yml"
+      run: NAMESPACE=artsy scripts/validate_orb.sh {staged_files}
+    validate-circle-config:
+      glob: ".circleci/config.yml"
+      run: circleci config validate
+    validate-shell-scripts:
+      glob: "*.sh"
+      run: shellcheck {staged_files}
+
+lint-all-scripts:
+  commands:
+    lint-scripts:
+      glob: "*.sh"
+      run: shellcheck {all_files}

--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -16,6 +16,11 @@ get_orb_path() {
   echo $YML_PATH
 }
 
+get_orb_from_path() {
+  local filename="$(basename $1)"
+  echo ${filename%.*}
+}
+
 get_orb_version() {
   local YML_PATH=$(get_orb_path $1)
 
@@ -26,15 +31,15 @@ get_orb_version() {
 }
 
 is_orb_changed() {
-    check_for_namespace
+  check_for_namespace
 
-    local ORB="$1"
-    local ORB_PATH="$(get_orb_path $ORB)"
-    local CHANGED="$(git diff --name-only origin/master $ORB_PATH)"
+  local ORB="$1"
+  local ORB_PATH="$(get_orb_path $ORB)"
+  local CHANGED="$(git diff --name-only origin/master $ORB_PATH)"
 
-    if [ ! -z "$CHANGED" ]; then
-      echo "true"
-    fi
+  if [ ! -z "$CHANGED" ]; then
+    echo "true"
+  fi
 }
 
 is_orb_created() {
@@ -47,7 +52,10 @@ is_orb_created() {
 
 is_orb_published() {
   check_for_namespace
-  local PUBLISHED=$(circleci orb info $NAMESPACE/$1 > /dev/null 2>&1; echo $?)
+  local PUBLISHED=$(
+    circleci orb info $NAMESPACE/$1 >/dev/null 2>&1
+    echo $?
+  )
   if [ "$PUBLISHED" -eq "0" ]; then
     echo "true"
   fi
@@ -64,10 +72,10 @@ compare_version() {
   local LESS="<"
   local EQUAL="="
 
-  IFS='.' read -ra VERSION1 <<< "$1"
-  IFS='.' read -ra VERSION2 <<< "$2"
+  IFS='.' read -ra VERSION1 <<<"$1"
+  IFS='.' read -ra VERSION2 <<<"$2"
 
-  for ((i=0; i<${#VERSION1[@]}; ++i)); do
+  for ((i = 0; i < ${#VERSION1[@]}; ++i)); do
     if [ "${VERSION1[i]}" -gt "${VERSION2[i]}" ]; then
       echo $GREATER
       return

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 check_for_namespace
 
 ORB="$1"
-echo ""
-echo "Validating $NAMESPACE/$1 orb"
 
 if [ -f $ORB ]; then
   ORB_PATH="$ORB"
@@ -15,6 +13,9 @@ if [ -f $ORB ]; then
 else
   ORB_PATH=$(get_orb_path $ORB)
 fi
+
+echo ""
+echo "Validating $NAMESPACE/$ORB orb"
 
 if [ ! -f "$ORB_PATH" ]; then
   echo "No orb exists at $ORB_PATH"

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -9,7 +9,12 @@ ORB="$1"
 echo ""
 echo "Validating $NAMESPACE/$1 orb"
 
-ORB_PATH=$(get_orb_path $ORB)
+if [ -f $ORB ]; then
+  ORB_PATH="$ORB"
+  ORB=$(get_orb_from_path $ORB)
+else
+  ORB_PATH=$(get_orb_path $ORB)
+fi
 
 if [ ! -f "$ORB_PATH" ]; then
   echo "No orb exists at $ORB_PATH"
@@ -48,7 +53,7 @@ if [ ! -z "$IS_CREATED" ] && [ ! -z "$IS_PUBLISHED" ]; then
       fi
     done
 
-  fi 
+  fi
 
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Install any missing development dependencies
+
+echo -n "Checking for cicleci... "
+if ! [ -x "$(command -v circleci)" ]; then
+  echo "not found, installing"
+  brew install circleci
+  echo "You'll need to create a personal circle api key to use the cli. Opening that page now..."
+  sleep 2
+  open https://circleci.com/account/api
+  echo "Once your done creating a token, finish the circle setup..."
+  sleep 3
+  circleci setup
+else
+  echo "found, skipping."
+fi
+
+echo -n "Checking for lefthook... "
+if ! [ -x "$(command -v lefthook)" ]; then
+  echo "not found, installing"
+  brew install Arkweid/lefthook/lefthook
+else
+  echo "found, skipping."
+fi
+
+echo -n "Checking for spellcheck... "
+if ! [ -x "$(command -v shellcheck)" ]; then
+  echo "not found, installing"
+  brew install shellcheck
+else
+  echo "found, skipping."
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Install any missing development dependencies
+# Sets up development dependencies
 
 echo -n "Checking for cicleci... "
 if ! [ -x "$(command -v circleci)" ]; then
@@ -20,6 +20,7 @@ echo -n "Checking for lefthook... "
 if ! [ -x "$(command -v lefthook)" ]; then
   echo "not found, installing"
   brew install Arkweid/lefthook/lefthook
+  lefthook install
 else
   echo "found, skipping."
 fi


### PR DESCRIPTION
This PR adds some (optional) pre-commit hooks to the orbs repo to assist catching issues before things before things get to CI. 

I'm using [lefthook](https://github.com/Arkweid/lefthook) to perform the actual pre-commit hook action. 

There's a new script file in the root called `setup.sh` which will help install the proper dependencies/set up the commit hooks. For now it only works on OSX. 

In order to get the pre-commit hook to work with `validate_orb.sh` I had to slightly update that file to also be able to take a path to an orb (as opposed to just the name which is how it operated previously). 

This _also_ introduces a tool called [shellcheck](https://github.com/koalaman/shellcheck) which is basically a linter for shell scripts. There are numerous things to fix there, but I'll do that in a follow up PR. 