### PR TITLE
update hokusai orb for Hokusai version 0.5.9

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.7.2
+# Orb Version 0.7.3
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5
+      - image: artsy/hokusai:0.5.9
 
 commands:
   setup:
@@ -61,16 +61,25 @@ commands:
     parameters:
       filename:
         type: string
-        default: ./hokusai/test.yml
+        default: ""
         description: The docker-compose yaml file to use
       flags:
         type: string
         default: ""
         description: Optional hokusai flags
     steps:
-      - run:
-          name: Test
-          command: hokusai test -f << parameters.filename >> << parameters.flags >>
+      - when:
+          condition: << parameters.filename >>
+          steps:
+            - run:
+                name: Test
+                command: hokusai test -f << parameters.filename >> << parameters.flags >>
+      - unless:
+          condition: << parameters.filename >>
+          steps:
+            - run:
+                name: Test
+                command: hokusai test << parameters.flags >>
 
 jobs:
   test:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -51,6 +51,7 @@ commands:
       - run:
           name: Push
           command: |
+            set +euo pipefail
             if hokusai registry images --limit 1000 | grep -q $CIRCLE_SHA1; then
               echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry"
             else


### PR DESCRIPTION
- Pin hokusai to version 0.5.9 so we roll out new Hokusai releases in CI by releasing a new version of this orb referencing the new version and allowing dependabot to update projects
- Introduce the `when` conditional in test job so that `hokusai test -f` is only called when a filename parameter is present  and we want to override the default behavior