### PR TITLE
Fix env check in orb-tools

### DIFF
--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.4.0
+# Orb Version 0.4.1
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy
@@ -18,12 +18,10 @@ commands:
       - run:
           name: Check for environment variables
           command: |
-            IFS=',' read -ra envs \<\<\< "<< parameters.env-vars >>"
-
             #Print the split string
-            for env in "${envs[@]}"; do
-              if [ -z "$env" ]; then
-                echo "The env var '$env' was expected to be set, but isn't. Set it and then try again."\
+            for env in << parameters.env-vars >>; do
+              if [ -z "$(printenv $env)" ]; then
+                echo "The env var '$env' was expected to be set, but isn't. Set it and then try again."
                 exit 1
               fi
             done

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 5.1.0
+# Orb Version 5.1.1
 
 version: 2.1
 description: Common yarn commands
@@ -7,7 +7,7 @@ orbs:
   node: artsy/node@1.0.0
   queue: eddiewebb/queue@1.0.110
   slack: circleci/slack@3.4.2
-  utils: artsy/orb-tools@dev:55f6486eeacc499426acd697242595df
+  utils: artsy/orb-tools@dev:4ab104781797303488b75d3fd18e99ee
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching


### PR DESCRIPTION
There's a bash syntax error in the environment variables check. Just trying to fix that. 