### PR TITLE
Add shortcut for not running job on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ workflows:
   build:
     jobs:
       - validate_orbs:
+          context: circleci-api
           filters:
             branches:
               ignore:

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -39,6 +39,8 @@ jobs:
         type: string
         default: ""
     steps:
-      - utils/skip-if-fork-or-not-pr
+      - utils/skip-if-fork-or-not-pr:
+          pr-skip-message: Skipping, only deploys canaries on PR builds
+          fork-skip-message: Skipping, can't deploy canaries from a fork
       - yarn/pre-release
       - auto/canary

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.2.1
+# Orb Version 1.2.2
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto
@@ -7,6 +7,7 @@ orbs:
   yarn: artsy/yarn@4.0.0
   node: artsy/node@0.1.0
   auto: auto/release@0.1.0
+  utils: artsy/orb-tools@dev:da826a2455c0d9f9ce31f71db9b0601e
 
 jobs:
   # Publishes a package to NPM
@@ -38,17 +39,6 @@ jobs:
         type: string
         default: ""
     steps:
-      - run:
-          name: Don't deploy canary if it's not a PR or if it's a fork
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              echo "Skipping, only deploys canaries on PR builds"
-              circleci-agent step halt
-            fi
-
-            if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              echo "Skipping, can't deploy canaries for forks due to permissions issues."
-              circleci-agent step halt
-            fi
+      - utils/skip-if-fork-or-not-pr
       - yarn/pre-release
       - auto/canary

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.4.1
+# Orb Version 0.5.0
 
 version: 2.1
 description: A simple set of tools for managing orbs by Artsy
@@ -18,6 +18,11 @@ commands:
       - run:
           name: Check for environment variables
           command: |
+            # Skip Forks
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Skipping, forks won't have the right env vars anyway."
+              exit 0
+            fi
             #Print the split string
             for env in << parameters.env-vars >>; do
               if [ -z "$(printenv $env)" ]; then
@@ -25,6 +30,27 @@ commands:
                 exit 1
               fi
             done
+  skip-if-fork-or-not-pr:
+    parameters:
+      pr-skip-message:
+        type: string
+        default: Skipping because this isn't a pr build
+      fork-skip-message:
+        type: string
+        default: Skipping because this is a fork
+    steps:
+      - run:
+          name: Don't deploy canary if it's not a PR or if it's a fork
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "<< parameters.pr-skip-message >>"
+              circleci-agent step halt
+            fi
+
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "<< parameters.fork-skip-message >>"
+              circleci-agent step halt
+            fi
   setup-paths:
     steps:
       - run:

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 5.1.1
+# Orb Version 5.1.2
 
 version: 2.1
 description: Common yarn commands
@@ -7,7 +7,7 @@ orbs:
   node: artsy/node@1.0.0
   queue: eddiewebb/queue@1.0.110
   slack: circleci/slack@3.4.2
-  utils: artsy/orb-tools@dev:4ab104781797303488b75d3fd18e99ee
+  utils: artsy/orb-tools@dev:da826a2455c0d9f9ce31f71db9b0601e
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching
@@ -172,17 +172,18 @@ jobs:
             - run:
                 name: jest
                 command: yarn jest --coverage --reporters=default --reporters=jest-junit << parameters.args >>
-      - when:
-          condition: << parameters.notify_slack_on_failure >>
-          steps:
-            - slack/status:
-                fail_only: true
-                only_for_branches: master
-                failure_message: $CIRCLE_PROJECT_REPONAME's tests failed for master
       - store_test_results:
           path: reports/junit
       - store_artifacts:
           path: reports/junit
+      - when:
+          condition: << parameters.notify_slack_on_failure >>
+          steps:
+            - utils/skip-if-fork-or-not-pr
+            - slack/status:
+                fail_only: true
+                only_for_branches: master
+                failure_message: $CIRCLE_PROJECT_REPONAME's tests failed for master
 
   update-cache:
     executor: node/build


### PR DESCRIPTION
Jest tests are failing on forks due to an env var check for slack stuff. This aims to fix that. 