### PR TITLE
Only deploy canary if canary label present

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.2.1
+# Orb Version 1.3.0
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto
@@ -6,7 +6,7 @@ description: Publish NPM packages and canary deployments with Intuit's Auto
 orbs:
   yarn: artsy/yarn@4.0.0
   node: artsy/node@0.1.0
-  auto: auto/release@0.1.0
+  auto: auto/release@0.2.3
 
 jobs:
   # Publishes a package to NPM


### PR DESCRIPTION
This updates which version of the `auto/release` orb that we're using. In 0.2.3 of `auto/release` a canary will only be released if the `canary` label is present on a PR. 