### PR TITLE
update to hokusai 0.5.10 and add an executor parameter to switch between versioned and beta hokusai build - bump hokusai and remote docker versions

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5.9
+      - image: artsy/hokusai:0.5.10
   beta:
     docker:
       - image: artsy/hokusai:beta

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.7.3
+# Orb Version 0.7.4
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -87,9 +87,9 @@ commands:
 
 jobs:
   test:
-    executor: << parameters.executor >>
+    executor: << parameters.e >>
     parameters:
-      executor:
+      e:
         type: executor
         default: deploy
       filename:
@@ -107,18 +107,18 @@ jobs:
           flags: << parameters.flags >>
 
   push:
-    executor: << parameters.executor >>
+    executor: << parameters.e >>
     parameters:
-      executor:
+      e:
         type: executor
         default: deploy
     steps:
       - push-image
 
   deploy-staging:
-    executor: << parameters.executor >>
+    executor: << parameters.e >>
     parameters:
-      executor:
+      e:
         type: executor
         default: deploy
       project-name:
@@ -144,9 +144,9 @@ jobs:
           command: git push git@github.com:artsy/<< parameters.project-name >>.git $CIRCLE_SHA1:refs/heads/staging --force
 
   deploy-production:
-    executor: << parameters.executor >>
+    executor: << parameters.e >>
     parameters:
-      executor:
+      e:
         type: executor
         default: deploy
       time-out:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -91,7 +91,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: hokusai/deploy
+        default: deploy
       filename:
         type: string
         default: ./hokusai/test.yml
@@ -111,7 +111,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: hokusai/deploy
+        default: deploy
     steps:
       - push-image
 
@@ -120,7 +120,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: hokusai/deploy
+        default: deploy
       project-name:
         type: string
         description: The name of the project as it appears on github
@@ -148,7 +148,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: hokusai/deploy
+        default: deploy
       time-out:
         type: string
         description: How long to wait for shell output before timing out

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -87,9 +87,9 @@ commands:
 
 jobs:
   test:
-    executor: << parameters.e >>
+    executor: << parameters.executor >>
     parameters:
-      e:
+      executor:
         type: executor
         default: deploy
       filename:
@@ -107,18 +107,18 @@ jobs:
           flags: << parameters.flags >>
 
   push:
-    executor: << parameters.e >>
+    executor: << parameters.executor >>
     parameters:
-      e:
+      executor:
         type: executor
         default: deploy
     steps:
       - push-image
 
   deploy-staging:
-    executor: << parameters.e >>
+    executor: << parameters.executor >>
     parameters:
-      e:
+      executor:
         type: executor
         default: deploy
       project-name:
@@ -144,9 +144,9 @@ jobs:
           command: git push git@github.com:artsy/<< parameters.project-name >>.git $CIRCLE_SHA1:refs/heads/staging --force
 
   deploy-production:
-    executor: << parameters.e >>
+    executor: << parameters.executor >>
     parameters:
-      e:
+      executor:
         type: executor
         default: deploy
       time-out:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -91,7 +91,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: deploy
+        default: hokusai/deploy
       filename:
         type: string
         default: ./hokusai/test.yml
@@ -111,7 +111,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: deploy
+        default: hokusai/deploy
     steps:
       - push-image
 
@@ -120,7 +120,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: deploy
+        default: hokusai/deploy
       project-name:
         type: string
         description: The name of the project as it appears on github
@@ -148,7 +148,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: deploy
+        default: hokusai/deploy
       time-out:
         type: string
         description: How long to wait for shell output before timing out

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -9,7 +9,7 @@ executors:
       - image: artsy/hokusai:0.5.9
   beta:
     docker:
-      - image: artsy/hokusai:head
+      - image: artsy/hokusai:beta
 
 commands:
   setup:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -7,6 +7,9 @@ executors:
   deploy:
     docker:
       - image: artsy/hokusai:0.5.9
+  beta:
+    docker:
+      - image: artsy/hokusai:head
 
 commands:
   setup:
@@ -84,8 +87,11 @@ commands:
 
 jobs:
   test:
-    executor: deploy
+    executor: << parameters.executor >>
     parameters:
+      executor:
+        type: executor
+        default: deploy
       filename:
         type: string
         default: ./hokusai/test.yml
@@ -101,13 +107,20 @@ jobs:
           flags: << parameters.flags >>
 
   push:
-    executor: deploy
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        type: executor
+        default: deploy
     steps:
       - push-image
 
   deploy-staging:
-    executor: deploy
+    executor: << parameters.executor >>
     parameters:
+      executor:
+        type: executor
+        default: deploy
       project-name:
         type: string
         description: The name of the project as it appears on github
@@ -131,8 +144,11 @@ jobs:
           command: git push git@github.com:artsy/<< parameters.project-name >>.git $CIRCLE_SHA1:refs/heads/staging --force
 
   deploy-production:
-    executor: deploy
+    executor: << parameters.executor >>
     parameters:
+      executor:
+        type: executor
+        default: deploy
       time-out:
         type: string
         description: How long to wait for shell output before timing out

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -5,7 +5,7 @@ description: >
   Excute Docker build via Artsy-managed Docker daemon with a Circle CI fallback
 
 orbs:
-  hokusai: artsy/hokusai@0.7.3
+  hokusai: artsy/hokusai@0.7.4
 
 commands:
   setup-artsy-remote-docker:

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.3
+# Orb Version 0.1.4
 
 version: 2.1
 description: >
@@ -93,8 +93,11 @@ commands:
 
 jobs:
   build:
-    executor: hokusai/deploy
+    executor: << parameters.executor >>
     parameters:
+      executor:
+        type: executor
+        default: hokusai/deploy
       artsy_docker_host:
         type: string
         default: docker.artsy.net

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -96,7 +96,27 @@ commands:
               --skip-latest
             printf "%s Image pushed.\n" "$(TZ=UTC date)"
 
+  test:
+    steps:
+      - run: hokusai registry pull --tag "$CIRCLE_SHA1"
+      - run:
+          name: Test
+          command: hokusai test --no-build
+          no_output_timeout: 3600s
+
 jobs:
+  test:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        type: executor
+        default: deploy
+    steps:
+      - add_ssh_keys
+      - checkout
+      - setup_remote_docker
+      - test
+
   build:
     executor: << parameters.executor >>
     parameters:

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -4,8 +4,13 @@ version: 2.1
 description: >
   Excute Docker build via Artsy-managed Docker daemon with a Circle CI fallback
 
-orbs:
-  hokusai: artsy/hokusai@0.7.4
+executors:
+  deploy:
+    docker:
+      - image: artsy/hokusai:0.5.10
+  beta:
+    docker:
+      - image: artsy/hokusai:beta
 
 commands:
   setup-artsy-remote-docker:
@@ -97,7 +102,7 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: hokusai/deploy
+        default: deploy
       artsy_docker_host:
         type: string
         default: docker.artsy.net


### PR DESCRIPTION
Updates hokusai default version to 0.5.10

CI builds can to opt-in to a hokusai beta build using the parameter `executor: hokusai/beta`

Parameterized executors are described [here](https://circleci.com/docs/2.0/reusing-config/#executor)

Adds a `remote-docker/test` job.