### PR TITLE
Use BUILD_TARGET var

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -59,13 +59,12 @@ commands:
               source $BASH_ENV
 
               printf "%s Building image...\n" "$(TZ=UTC date)"
-              BUILD_TAG="$CIRCLE_SHA1" hokusai build
+              BUILD_TARGET="$BUILD_TARGET" hokusai build
               printf "%s Image built.\n" "$(TZ=UTC date)"
 
               printf "%s Pushing image...\n" "$(TZ=UTC date)"
               hokusai registry push \
                 --no-build \
-                --local-tag="$CIRCLE_SHA1" \
                 --tag="$CIRCLE_SHA1" \
                 --overwrite \
                 --skip-latest
@@ -84,13 +83,12 @@ commands:
           no_output_timeout: 15m
           command: |
             printf "%s Building image...\n" "$(TZ=UTC date)"
-            BUILD_TAG="$CIRCLE_SHA1" hokusai build
+            BUILD_TARGET="$BUILD_TARGET" hokusai build
             printf "%s Image built.\n" "$(TZ=UTC date)"
 
             printf "%s Pushing image...\n" "$(TZ=UTC date)"
             hokusai registry push \
               --no-build \
-              --local-tag="$CIRCLE_SHA1" \
               --tag="$CIRCLE_SHA1" \
               --overwrite \
               --skip-latest

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -59,12 +59,13 @@ commands:
               source $BASH_ENV
 
               printf "%s Building image...\n" "$(TZ=UTC date)"
-              BUILD_TARGET="$BUILD_TARGET" hokusai build
+              BUILD_TARGET="$BUILD_TARGET" BUILD_TAG="$CIRCLE_SHA1" hokusai build
               printf "%s Image built.\n" "$(TZ=UTC date)"
 
               printf "%s Pushing image...\n" "$(TZ=UTC date)"
               hokusai registry push \
                 --no-build \
+                --local-tag="$CIRCLE_SHA1" \
                 --tag="$CIRCLE_SHA1" \
                 --overwrite \
                 --skip-latest
@@ -83,12 +84,13 @@ commands:
           no_output_timeout: 15m
           command: |
             printf "%s Building image...\n" "$(TZ=UTC date)"
-            BUILD_TARGET="$BUILD_TARGET" hokusai build
+            BUILD_TARGET="$BUILD_TARGET" BUILD_TAG="$CIRCLE_SHA1" hokusai build
             printf "%s Image built.\n" "$(TZ=UTC date)"
 
             printf "%s Pushing image...\n" "$(TZ=UTC date)"
             hokusai registry push \
               --no-build \
+              --local-tag="$CIRCLE_SHA1" \
               --tag="$CIRCLE_SHA1" \
               --overwrite \
               --skip-latest
@@ -104,8 +106,6 @@ commands:
 
 jobs:
   test:
-    environment:
-      BUILD_TARGET: builder
     executor: << parameters.executor >>
     parameters:
       executor:

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.5
+# Orb Version 0.1.6
 
 version: 2.1
 description: >

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -104,6 +104,8 @@ commands:
 
 jobs:
   test:
+    environment:
+      BUILD_TARGET: builder
     executor: << parameters.executor >>
     parameters:
       executor:


### PR DESCRIPTION
Adds argument for "BUILD_TARGET" to pass a target to docker-compose. 
If the var is not provided, Docker will build the entire image. This var is only needed to stop at an earlier stage.

Related to https://github.com/artsy/horizon/pull/201