### PR TITLE
Allow configUri to be passed from deploy steps

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -39,14 +39,27 @@ commands:
     parameters:
       configUri:
         type: string
-        default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml"
+        # configure the default in the unless statement
+        default: ""
     steps:
-      - run:
-          name: Configure Hokusai
-          command: |
-            mkdir -p ~/.hokusai
-            curl -o ~/.hokusai/config.yml << parameters.configUri >>
-            hokusai configure
+      - when:
+          condition: << parameters.configUri >>
+          steps:
+            - run:
+                name: Configure Hokusai
+                command: |
+                  mkdir -p ~/.hokusai
+                  curl -o ~/.hokusai/config.yml << parameters.configUri >>
+                  hokusai configure
+      - unless:
+          condition: << parameters.configUri >>
+          steps:
+            - run:
+                name: Configure Hokusai
+                command: |
+                  mkdir -p ~/.hokusai
+                  curl -o ~/.hokusai/config.yml https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml
+                  hokusai configure
 
   push-image:
     steps:
@@ -128,10 +141,14 @@ jobs:
         type: string
         description: How long to wait for shell output before timing out
         default: 20m
+      configUri:
+        type: string
+        default: ""
     steps:
       - setup
       - install-aws-iam-authenticator
-      - configure-hokusai
+      - configure-hokusai:
+          configUri: << parameters.configUri >>
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai staging update --skip-checks --dry-run
@@ -153,10 +170,14 @@ jobs:
         type: string
         description: How long to wait for shell output before timing out
         default: 20m
+      configUri:
+        type: string
+        default: ""
     steps:
       - setup
       - install-aws-iam-authenticator
-      - configure-hokusai
+      - configure-hokusai:
+          configUri: << parameters.configUri >>
       - run:
           name: Validate Kubernetes Yaml
           command: hokusai production update --skip-checks --dry-run

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -45,27 +45,29 @@ commands:
     parameters:
       configUri:
         type: string
-        # configure the default in the unless statement
+        # configure the default in DEFAULT_CONFIG_PATH
         default: ""
     steps:
-      - when:
-          condition: << parameters.configUri >>
-          steps:
-            - run:
-                name: Configure Hokusai
-                command: |
-                  mkdir -p ~/.hokusai
-                  curl -o ~/.hokusai/config.yml << parameters.configUri >>
-                  hokusai configure
-      - unless:
-          condition: << parameters.configUri >>
-          steps:
-            - run:
-                name: Configure Hokusai
-                command: |
-                  mkdir -p ~/.hokusai
-                  curl -o ~/.hokusai/config.yml https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml
-                  hokusai configure
+      - run:
+          name: Configure Hokusai
+          # Order of precedence of config path:
+          #   1. parameter
+          #   2. environment variable
+          #   3. default
+          command: |
+            DEFAULT_CONFIG_PATH=https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml
+
+            if [[ ! -z "<< parameters.configUri >>" ]]; then
+              CONFIG="<< parameters.configUri >>"
+            elif [[ ! -z "$HOKUSAI_CONFIG_PATH" ]]
+              CONFIG="$HOKUSAI_CONFIG_PATH"
+            else
+              CONFIG="$DEFAULT_CONFIG_PATH"
+            fi
+
+            mkdir -p ~/.hokusai
+            curl -o ~/.hokusai/config.yml "$CONFIG"
+            hokusai configure
 
   push-image:
     steps:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.7.6
+# Orb Version 0.7.7
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments


### PR DESCRIPTION
Requested by @izakp.

This PR allows the deploy step to provide the configUri parameter to the `configure-hokusai` job.

Passing down params is a little cumbersome without making a breaking change. You either have to hoist the default _or_ do something like I did here....

Essentially, to keep the default for `configUri` contained in `configure-hokusai` I modified `configure-hokusai` to check for an empty string. When it's not empty, it'll use the parameter. When it is, it uses a hard coded default. 

If someone can think of a better way of doing this w/o introducing a breaking change I'm all ears.