### PR TITLE
#WIP - Test CI deploy to new prod k8s cluster pictor.

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -45,7 +45,7 @@ commands:
     parameters:
       configUri:
         type: string
-        default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci-leo.yml"
+        default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci-pictor.yml"
     steps:
       - run:
           name: Configure Hokusai

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -45,7 +45,7 @@ commands:
     parameters:
       configUri:
         type: string
-        default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci.yml"
+        default: "https://artsy-provisioning-public.s3.amazonaws.com/hokusai/config-ci-leo.yml"
     steps:
       - run:
           name: Configure Hokusai


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3016

Preparing new prod k8s cluster `pictor`. Created test CI configs in s3. Would like a dev hokusai orb. Will use this orb to deploy `hokusai-sandbox` to new cluster.

Test CI configs:
`s3://artsy-provisioning-public/hokusai/config-ci-pictor.yml`
`s3://artsy-citadel/k8s/config-ci-pictor`