### PR TITLE
fix: specify node version for hokusai

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -65,7 +65,7 @@ commands:
         type: string
         default: 19.03.13
     steps:
-      - setup-docker
+      - setup-docker:
           remote_docker_version: << parameters.remote_docker_version >>
       - run:
           name: Push
@@ -121,7 +121,7 @@ jobs:
         default: 19.03.13
         description: specify circleci remote docker version
     steps:
-      - setup-docker
+      - setup-docker:
           remote_docker_version: << parameters.remote_docker_version >>
       - run-tests:
           filename: << parameters.filename >>
@@ -137,7 +137,7 @@ jobs:
         type: string
         default: 19.03.13
     steps:
-      - push-image
+      - push-image:
           remote_docker_version: << parameters.remote_docker_version >>
 
   deploy-staging:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,6 +1,6 @@
 # Orb Version 0.7.7
 
-version: 2.2
+version: 2.1
 description: Reusable hokusai tasks for managing deployments
 
 executors:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -27,7 +27,7 @@ commands:
     steps:
       - setup
       - setup_remote_docker:
-        version: 19.03.13
+          version: 19.03.13
 
   install-aws-iam-authenticator:
     parameters:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,6 +1,6 @@
 # Orb Version 0.7.7
 
-version: 2.1
+version: 2.2
 description: Reusable hokusai tasks for managing deployments
 
 executors:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -26,7 +26,8 @@ commands:
   setup-docker:
     steps:
       - setup
-      - setup_remote_docker
+      - setup_remote_docker:
+        version: 19.03.13
 
   install-aws-iam-authenticator:
     parameters:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -24,10 +24,14 @@ commands:
       - checkout
 
   setup-docker:
+    parameters:
+      remote_docker_version:
+        type: string
+        default: 19.03.13
     steps:
       - setup
       - setup_remote_docker:
-          version: 19.03.13
+          version: << parameters.remote_docker_version >>
 
   install-aws-iam-authenticator:
     parameters:
@@ -56,8 +60,13 @@ commands:
             hokusai configure
 
   push-image:
+    parameters:
+      remote_docker_version:
+        type: string
+        default: 19.03.13
     steps:
       - setup-docker
+          remote_docker_version: << parameters.remote_docker_version >>
       - run:
           name: Push
           command: |
@@ -107,8 +116,13 @@ jobs:
         type: string
         default: ""
         description: Optional hokusai flags
+      remote_docker_version:
+        type: string
+        default: 19.03.13
+        description: specify circleci remote docker version
     steps:
       - setup-docker
+          remote_docker_version: << parameters.remote_docker_version >>
       - run-tests:
           filename: << parameters.filename >>
           flags: << parameters.flags >>
@@ -119,8 +133,12 @@ jobs:
       executor:
         type: executor
         default: deploy
+      remote_docker_version:
+        type: string
+        default: 19.03.13
     steps:
       - push-image
+          remote_docker_version: << parameters.remote_docker_version >>
 
   deploy-staging:
     executor: << parameters.executor >>


### PR DESCRIPTION
Full disclosure: I have no idea what I'm doing 😁

Per [this slack conversation](https://artsy.slack.com/archives/CP9P4KR35/p1610383159088400) and [this doc from circle](https://support.circleci.com/hc/en-us/articles/360050934711), it appears to be necessary to specify the docker version for hokusai builds to avoid [permission errors](https://app.circleci.com/pipelines/github/artsy/convection/1985/workflows/9fbb3b80-d743-4ac2-a704-7cfe9067dfeb/jobs/2687). 

Things I don't know but would love to learn if anyone has a decisive answer or opinion: 
* How to test that this will fix the issue without merging & re-attempting a convection build
* If making this change globally will negatively affect any other builds.
* If the specified docker version is the correct version. The linked doc uses that version, but it doesn't say much about _why_ other docker versions cause that issue, and I haven't found any other docs that explain why that specific version is best. 