### PR TITLE
feat: use version 19.03.13 for CircleCI remote docker build, and introduce a parameter for version.

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.7.7
+# Orb Version 0.7.8
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -24,9 +24,14 @@ commands:
       - checkout
 
   setup-docker:
+    parameters:
+      remote_docker_version:
+        type: string
+        default: 19.03.13
     steps:
       - setup
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: << parameters.remote_docker_version >>
 
   install-aws-iam-authenticator:
     parameters:
@@ -55,8 +60,13 @@ commands:
             hokusai configure
 
   push-image:
+    parameters:
+      remote_docker_version:
+        type: string
+        default: 19.03.13
     steps:
-      - setup-docker
+      - setup-docker:
+          remote_docker_version: << parameters.remote_docker_version >>
       - run:
           name: Push
           command: |
@@ -106,8 +116,13 @@ jobs:
         type: string
         default: ""
         description: Optional hokusai flags
+      remote_docker_version:
+        type: string
+        default: 19.03.13
+        description: specify circleci remote docker version
     steps:
-      - setup-docker
+      - setup-docker:
+          remote_docker_version: << parameters.remote_docker_version >>
       - run-tests:
           filename: << parameters.filename >>
           flags: << parameters.flags >>
@@ -118,8 +133,12 @@ jobs:
       executor:
         type: executor
         default: deploy
+      remote_docker_version:
+        type: string
+        default: 19.03.13
     steps:
-      - push-image
+      - push-image:
+          remote_docker_version: << parameters.remote_docker_version >>
 
   deploy-staging:
     executor: << parameters.executor >>


### PR DESCRIPTION
https://artsy.slack.com/archives/CP9P4KR35/p1610383159088400

Convection/Pulse docker builds started to fail on CircleCI (yet works fine locally). Exact trigger not known but I suspect triggered by some CircleCI change. The builds utilize Circle's remote docker engine whose [version](https://circleci.com/docs/2.0/building-docker-images/#docker-version) by default is `17.09.0-ce`.

CircleCI allows specifying docker version via `version` parameter to `setup_remote_docker`. We tested with a dev orb and found that both apps build fine on version `19.03.13`.

Therefore, we are going with that version for all builds.

The problem is [known](https://support.circleci.com/hc/en-us/articles/360050934711) to CircleCI. It sounds like both are factors - version of nodejs, and version of docker. Nodejs version across our projects varies. It is possible that some projects fail to build on the new docker version. To guard against that, we decided to make docker version a parameter that defaults to `19.03.13`.

Thanks @pepopowitz , @starsirius , @izakp , @zephraph for collaborating.

Convection test builds:
- Using [19.03.13](https://app.circleci.com/pipelines/github/artsy/convection/1992/workflows/aa3d089d-b6db-4332-b0a7-c1d17c974f57/jobs/2695) as defaulted by orb.
- Using [19.03.12](https://app.circleci.com/pipelines/github/artsy/convection/1991/workflows/8fade039-882e-46f1-a3bb-d2c05292bfd0/jobs/2694) passed into orb as a parameter, to show that it's doable.