### PR TITLE
change the default file for the next version

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -110,7 +110,7 @@ jobs:
         default: deploy
       filename:
         type: string
-        default: ./hokusai/test.yml
+        default: ./hokusai/test.yml.j2
         description: The docker-compose yaml file to use
       flags:
         type: string

--- a/src/release/release.yml
+++ b/src/release/release.yml
@@ -33,7 +33,7 @@ jobs:
 
 # Below is used to test this orb. Just uncomment the workflows setting and run the following command
 
-# circleci config process src/release/release.yml > test.yml && circleci local execute --job block -c ./test.yml -e HORIZON_USER=<USER> -e HORIZON_PASS=<PASS> -e TEST_DEPLOY_BLOCK_PROJECT_ID=8
+# circleci config process src/release/release.yml.j2 > test.yml.j2 && circleci local execute --job block -c ./test.yml.j2 -e HORIZON_USER=<USER> -e HORIZON_PASS=<PASS> -e TEST_DEPLOY_BLOCK_PROJECT_ID=8
 
 # workflows:
 #   test:


### PR DESCRIPTION
Use `test.yml.j2` as default. I guess it should be bumped to 0.8.0 for this change, so either the repos that go to that version change the name, or they add a `filename: test.yml` in their circleci config.