### PR TITLE
chore: move step halt inside conditional

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -82,8 +82,8 @@ commands:
               printf "%s Image built.\n" "$(TZ=UTC date)"
 
               printf "Skipping local docker build fallback...\n"
+              circleci step halt
             fi
-            circleci step halt
 
   buildkit-push-image-via-artsy:
     steps:
@@ -115,8 +115,8 @@ commands:
               printf "%s Image pushed.\n" "$(TZ=UTC date)"
 
               printf "Skipping local docker build fallback...\n"
+              circleci step halt
             fi
-            circleci step halt
 
   build-image-via-artsy:
     steps:

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.11
+# Orb Version 0.1.12
 
 version: 2.1
 description: >


### PR DESCRIPTION
It looks like the fallback to Circle CI's local docker damon isn't working as expected. I suspect that it's because these skips are outside the conditional but we'll see...

cc/ @pvinis @icirellik 