### PR TITLE
fix: when falling back to circleci docker, use docker v19.03.13.

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -186,6 +186,7 @@ jobs:
       - add_ssh_keys
       - checkout
       - setup_remote_docker
+          version: 19.03.13
       - test
 
   build:
@@ -212,6 +213,7 @@ jobs:
           artsy_s3_path_root: << parameters.artsy_s3_path_root >>
       - build-image-via-artsy
       - setup_remote_docker
+          version: 19.03.13
       - build-image-via-circle
 
   buildkit-build:

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -185,7 +185,7 @@ jobs:
     steps:
       - add_ssh_keys
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
           version: 19.03.13
       - test
 
@@ -212,7 +212,7 @@ jobs:
           artsy_docker_port: << parameters.artsy_docker_port >>
           artsy_s3_path_root: << parameters.artsy_s3_path_root >>
       - build-image-via-artsy
-      - setup_remote_docker
+      - setup_remote_docker:
           version: 19.03.13
       - build-image-via-circle
 

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.11
+# Orb Version 0.1.12
 
 version: 2.1
 description: >


### PR DESCRIPTION
We [lock](https://github.com/artsy/orbs/blob/419acdaa221c1eecca9290b956fe2d940abaf17d/src/hokusai/hokusai.yml#L30) circleci docker version to v19.03.13 via hokusai orb.

This is done by specifying the version on every call of circleci's `setup_remote_docker` command.

So it's also required for `remote-docker` orb as it falls back to using circleci's docker. This PR does that.