### PR TITLE
Add the ability to run lerna bootstrap during setup

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 5.1.3
+# Orb Version 5.2.0
 
 version: 2.1
 description: Common yarn commands
@@ -39,15 +39,33 @@ commands:
       - run: yarn
 
   setup:
+    parameters:
+      bootstrap:
+        description: If lerna bootstrap should be ran prior to setup
+        type: boolean
+        default: false
     steps:
       - add_ssh_keys
       - checkout
       - load_dependencies
-      - install
+      - when:
+          condition: << parameters.bootstrap >>
+          steps:
+            - run: yarn lerna bootstrap
+      - unless:
+          condition: << parameters.bootstrap >>
+          steps:
+            - install
 
   update_dependencies:
+    parameters:
+      bootstrap:
+        description: If lerna bootstrap should be ran prior to setup
+        type: boolean
+        default: false
     steps:
-      - setup
+      - setup:
+          bootstrap: << parameters.bootstrap >>
       - save_dependencies
 
   run-script:
@@ -186,9 +204,15 @@ jobs:
                 failure_message: $CIRCLE_PROJECT_REPONAME's tests failed for master
 
   update-cache:
+    parameters:
+      bootstrap:
+        description: If lerna bootstrap should be ran on setup
+        type: boolean
+        default: false
     executor: node/build
     steps:
-      - update_dependencies
+      - update_dependencies:
+          bootstrap: << parameters.bootstrap >>
 
   # A job responsible for ensuring only 1 master build runs at a time so that
   # there are no deployment race conditions

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -39,21 +39,16 @@ commands:
       - run: yarn
 
   setup:
-    parameters:
-      bootstrap:
-        description: If lerna bootstrap should be ran prior to setup
-        type: boolean
-        default: false
     steps:
       - add_ssh_keys
       - checkout
       - load_dependencies
       - when:
-          condition: << parameters.bootstrap >>
+          condition: << pipeline.parameters.lerna-bootstrap >>
           steps:
             - run: yarn lerna bootstrap
       - unless:
-          condition: << parameters.bootstrap >>
+          condition: << parameters.lerna-bootstrap >>
           steps:
             - install
 

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -43,24 +43,18 @@ commands:
       - add_ssh_keys
       - checkout
       - load_dependencies
-      - when:
-          condition: << pipeline.parameters.lerna-bootstrap >>
-          steps:
-            - run: yarn lerna bootstrap
-      - unless:
-          condition: << parameters.lerna-bootstrap >>
-          steps:
-            - install
+      - run:
+          name: Install or bootstrap as necessary
+          command: |
+            if [ -z "$(printenv $LERNA_BOOTSTRAP)" ]; then
+              yarn install
+            else
+              yarn lerna bootstrap
+            fi
 
   update_dependencies:
-    parameters:
-      bootstrap:
-        description: If lerna bootstrap should be ran prior to setup
-        type: boolean
-        default: false
     steps:
-      - setup:
-          bootstrap: << parameters.bootstrap >>
+      - setup
       - save_dependencies
 
   run-script:
@@ -199,15 +193,9 @@ jobs:
                 failure_message: $CIRCLE_PROJECT_REPONAME's tests failed for master
 
   update-cache:
-    parameters:
-      bootstrap:
-        description: If lerna bootstrap should be ran on setup
-        type: boolean
-        default: false
     executor: node/build
     steps:
-      - update_dependencies:
-          bootstrap: << parameters.bootstrap >>
+      - update_dependencies
 
   # A job responsible for ensuring only 1 master build runs at a time so that
   # there are no deployment race conditions


### PR DESCRIPTION
Hey @damassi, this should basically do what you need for https://github.com/artsy/palette/pull/973.

It has the ability to use the `bootstrap` parameter to the `update-cache` job to have it run `lerna bootstrap`. I'm fairly sure this should work, but b/c I'm sending this through a PR you won't get a canary build. Maybe you should copy this branch to `orbs` and test the canary from there. 