### PR TITLE
chore: pass through orb parameters

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -4,8 +4,8 @@ version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto
 
 orbs:
-  yarn: artsy/yarn@4.0.0
-  node: artsy/node@0.1.0
+  yarn: artsy/yarn@5.1.3
+  node: artsy/node@1.0.0
   auto: auto/release@0.2.3
   utils: artsy/orb-tools@0.5.0
 

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,4 +1,4 @@
-# Orb Version 1.3.2
+# Orb Version 1.4.0
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     executor: node/build
     environment:
-      AUTO_VERSION: v9.27.2
+      AUTO_VERSION: << parameters.version >>
     parameters:
       version:
         type: string
@@ -24,13 +24,14 @@ jobs:
         default: ""
     steps:
       - yarn/pre-release
-      - auto/shipit
+      - auto/shipit:
+        arguments: << parameters.args >>
 
   # Publishes a canary package to npm
   publish-canary:
     executor: node/build
     environment:
-      AUTO_VERSION: v9.27.2
+      AUTO_VERSION: << parameters.version >>
     parameters:
       version:
         type: string
@@ -43,4 +44,5 @@ jobs:
           pr-skip-message: Skipping, only deploys canaries on PR builds
           fork-skip-message: Skipping, can't deploy canaries from a fork
       - yarn/pre-release
-      - auto/canary
+      - auto/canary:
+        arguments: << parameters.args >>


### PR DESCRIPTION
Two parameters were defined in our artsy/auto orb jobs but they don't seem to be used. This commit hooks up the two parameters (version and args) so that the values art properly threaded into the environment or the underlying auto/canary + auto/shipit orb jobs.