### PR TITLE
fix: escape backquotes

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.12
+# Orb Version 0.1.13
 
 version: 2.1
 description: >
@@ -51,7 +51,7 @@ commands:
                 exit 0
               fi
             else
-              printf "Required environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` unavailable. Reverting back to Circle CI docker.\n"
+              printf 'Required environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` unavailable. Reverting back to Circle CI docker.\n'
               exit 0
             fi
 


### PR DESCRIPTION
Noticing `AWS_ACCESS_KEY_ID` was evaluated to a command. Let's escape backquotes.

![Screen Shot 2021-07-27 at 2 01 03 PM](https://user-images.githubusercontent.com/796573/127204736-1e9ee9e9-6150-44d4-8209-de3e0b2526d8.png)
