### PR TITLE
feat: use hokusai v0.5.16, add retag-staging step.

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.8.0
+# Orb Version 0.9.0
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments
@@ -163,6 +163,17 @@ jobs:
       - run:
           name: Update Staging branch
           command: git push git@github.com:artsy/<< parameters.project-name >>.git $CIRCLE_SHA1:refs/heads/staging --force
+
+  retag-staging:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        type: executor
+        default: deploy
+    steps:
+      - run:
+          name: retag staging
+          command: hokusai registry retag staging foo
 
   deploy-production:
     executor: << parameters.executor >>

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -174,7 +174,7 @@ jobs:
       - setup
       - run:
           name: retag staging
-          command: hokusai registry retag staging foo
+          command: hokusai registry retag staging $CIRCLE_SHA1
 
   deploy-production:
     executor: << parameters.executor >>

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5.13
+      - image: artsy/hokusai:0.5.16
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -171,6 +171,7 @@ jobs:
         type: executor
         default: deploy
     steps:
+      - setup
       - run:
           name: retag staging
           command: hokusai registry retag staging foo


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3372

- Orb currently pointing to Hokusai `v0.5.13`. Point it to `v0.5.16` (currently the latest).
- Add `retag-staging` step which makes use of `hokusai registry retag` introduced in `v0.5.16`.