### PR TITLE
feat: use main branch, hokusai and yarn version bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - main
       - publish_orbs:
           context: circleci-api

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CircleCI 2.1 introduces [several new features](https://github.com/CircleCI-Publi
 
 For more info on Orbs, checkout their [docs](https://github.com/CircleCI-Public/config-preview-sdk/tree/master/docs)!
 
-(The TL;DR is there's an `orb` yml configuration file that's used to share things like [executors](orb-executors), [commands](orb-commands), and [jobs](orb-jobs) across your CircleCi builds.)
+(The TL;DR is there's an `orb` yml configuration file that's used to share things like [executors][orb-executors], [commands][orb-commands], and [jobs][orb-jobs] across your CircleCi builds.)
 
 ## Getting Started
 
@@ -33,11 +33,11 @@ There are two types of deployments that happen in this repo.
 
 When you make a change to an orb (and update the version) a canary version will be published. Check the build logs for the version name. This canary build can be used (before your PR is merged to main) to test orb changes in other projects. It's _highly_ recommended that you utilize this canary system to test changes that may impact many projects.
 
-Upon merging a PR, CI will publish the changed orbs to CircleCI's public registry. Artsy also has [renovate configuration](reno-config) to update orb changes across Artsy's GitHub org.
+Upon merging a PR, CI will publish the changed orbs to CircleCI's public registry. Artsy also has [renovate configuration][reno-config] to update orb changes across Artsy's GitHub org.
 
 The deployment process is driven by a set of bash scripts in the `scripts` directory. `publish_orbs.sh` is responsible for publishing both the canary and release version of the orbs. It's heavily commented and you're encouraged to read through it if you're interested in how the process works.
 
 [orb-executors]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
 [orb-commands]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
 [orb-jobs]: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
-[reno-config]: https://github.com/artsy/renovate-config/blob/f8d47916b38096ebf834985e926253dcc0f78e25/lib/config-builder.js#L55-L62
+[reno-config]: https://github.com/artsy/renovate-config/blob/1210eeba081c4aeb1369ed9257cbe7b1e76276e0/lib/config.js

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To make it easier to perform changes locally, it's recommended that you run `set
 
 ## Versioning
 
-Every orb has a comment like `# Orb Version 1.2.3` on the first line of the file. This comment is significant in that it's used to determine which version of the orb should be deployed (which will be discussed in the next section). Orbs in `master` will have a comment representing the currently deployed production version.
+Every orb has a comment like `# Orb Version 1.2.3` on the first line of the file. This comment is significant in that it's used to determine which version of the orb should be deployed (which will be discussed in the next section). Orbs in `main` will have a comment representing the currently deployed production version.
 
 When you make a change to an orb file you _must_ update the version. CI checks will fail otherwise.
 
@@ -29,9 +29,9 @@ When you make a change to an orb file you _must_ update the version. CI checks w
 There are two types of deployments that happen in this repo.
 
 1. Canary deployments that happen on every PR change
-2. Production deployments that happen when a PR is merged to master.
+2. Production deployments that happen when a PR is merged to main.
 
-When you make a change to an orb (and update the version) a canary version will be published. Check the build logs for the version name. This canary build can be used (before your PR is merged to master) to test orb changes in other projects. It's _highly_ recommended that you utilize this canary system to test changes that may impact many projects.
+When you make a change to an orb (and update the version) a canary version will be published. Check the build logs for the version name. This canary build can be used (before your PR is merged to main) to test orb changes in other projects. It's _highly_ recommended that you utilize this canary system to test changes that may impact many projects.
 
 Upon merging a PR, CI will publish the changed orbs to CircleCI's public registry. Artsy also has [renovate configuration](reno-config) to update orb changes across Artsy's GitHub org.
 

--- a/scripts/orb_utils.sh
+++ b/scripts/orb_utils.sh
@@ -35,7 +35,7 @@ is_orb_changed() {
 
   local ORB="$1"
   local ORB_PATH="$(get_orb_path "$ORB")"
-  local CHANGED="$(git diff --name-only origin/master "$ORB_PATH")"
+  local CHANGED="$(git diff --name-only origin/main "$ORB_PATH")"
 
   if [ -n "$CHANGED" ]; then
     echo "true"

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -21,7 +21,7 @@ BRANCH=$(git branch | grep "\*" | cut -d ' ' -f2)
 ORB="$1"
 IS_CHANGED=$(is_orb_changed "$ORB")
 
-if [ "$BRANCH" != "master" ] && [ -z "$IS_CHANGED" ]; then
+if [ "$BRANCH" != "main" ] && [ -z "$IS_CHANGED" ]; then
   echo "$(YELLOW "[skipped]") Publish for $NAMESPACE/$ORB because there are no changes"
   exit 0
 fi
@@ -55,14 +55,14 @@ elif [ -z "$DRY_RUN" ]; then
   exit 1
 fi
 
-# Build the dev version prefix. When not on the master branch this will be
+# Build the dev version prefix. When not on the main branch this will be
 # used to publish a dev version of the orb. That can be pulled in using
 # $NAMESPACE/<orb-name>@dev:<version>. This is useful for testing purposes.
 #
 # This will be referred to as "dev mode" in later comments
 DEV=""
 VERSION_POSTFIX=""
-if [ "$BRANCH" != "master" ]; then
+if [ "$BRANCH" != "main" ]; then
   DEV="dev:"
   echo "$(YELLOW "[Running in dev mode]")"
 
@@ -141,7 +141,7 @@ if [ -z "$DRY_RUN" ] && [ -z "$DEV" ] && [ -n "$SLACK_WEBHOOK_URL" ]; then
   ./slack \
     -color "good" \
     -title "Circle CI $ORB orb v$VERSION published!" \
-    -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/$NAMESPACE/orbs/tree/master}" \
+    -title_link "${CIRCLE_BUILD_URL:-https://circleci.com/gh/$NAMESPACE/orbs/tree/main}" \
     -user_name "artsyit" \
     -icon_emoji ":crystal_ball:"
 

--- a/scripts/validate_orb.sh
+++ b/scripts/validate_orb.sh
@@ -40,16 +40,16 @@ if [ -n "$IS_CREATED" ] && [ -n "$IS_PUBLISHED" ]; then
 
   PUBLISHED_VERSION=$(get_published_orb_version "$ORB")
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  if [ "$BRANCH" != "master" ]; then
+  if [ "$BRANCH" != "main" ]; then
 
-    CHANGED_FILES="$(git diff --name-only HEAD..origin/master)"
+    CHANGED_FILES="$(git diff --name-only HEAD..origin/main)"
     UPDATED_FILES="$(git status -s | cut -c4-)"
     #shellcheck disable=SC2206
     ALL_CHANGES=(${CHANGED_FILES[@]} ${UPDATED_FILES[@]})
     for file in "${ALL_CHANGES[@]}"; do
       if [[ "$ORB_PATH" == *"$file" ]] && [[ "$VERSION" == "$PUBLISHED_VERSION" ]]; then
         echo ""
-        echo "$NAMESPACE/$ORB has been updated since master but hasn't had its version bumped."
+        echo "$NAMESPACE/$ORB has been updated since main but hasn't had its version bumped."
         echo "Update its version in $ORB_PATH"
         exit 1
       fi

--- a/src/hokusai/README.md
+++ b/src/hokusai/README.md
@@ -2,11 +2,11 @@
 
 This orb is built to share hokusai configuration across many CircleCI setups. It currently provides CircleCI workflow steps for `test`, `deploy-staging` and `deploy-production`, using a PR-based release process. Use the latest version of this orb in your app to ensure that hokusai and all related libs are up to date, and that deployments use the latest recommended workflow.
 
-Enabling orbs requires CircleCI 2.1, which is enabled for an app in 2 steps: 
+Enabling orbs requires CircleCI 2.1, which is enabled for an app in 2 steps:
 - In CircleCI UI > App "Build Settings" > "Advanced Settings", turn the "Enable pipelines" radio to `true`.
-- In the app's `.circleci/config.yml`, set `version: 2.1` at the top of the file. 
+- In the app's `.circleci/config.yml`, set `version: 2.1` at the top of the file.
 
-If not already configured, a read+write Github key is required for CircleCI. Find [instructions for creating and saving this key here](https://github.com/artsy/README/blob/master/playbooks/deployments.md#recommendations).
+If not already configured, a read+write Github key is required for CircleCI. Find [instructions for creating and saving this key here](https://github.com/artsy/README/blob/main/playbooks/deployments.md#recommendations).
 
 To use the orb, within your app's `.circleci/config.yml`, use the hokusai orb for one or all workflow steps. It is recommended to use the orb for all steps, but implementation will depend on a particular app's needs.
 

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5.16
+      - image: artsy/hokusai:0.5.18
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.9.0
+# Orb Version 0.10.0
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 6.0.0
+# Orb Version 6.1.0
 
 version: 2.1
 description: Common yarn commands
@@ -134,7 +134,7 @@ jobs:
         default: false
       notify_slack_on_failure:
         description: |
-          If a slack message should be sent out if master fails. Requires SLACK_WEBHOOK environment
+          If a slack message should be sent out if building off of main branch fails. Requires SLACK_WEBHOOK environment
           variable to be set.
         type: boolean
         default: false
@@ -154,17 +154,17 @@ jobs:
                   important_files_modified() {
                     FILES="yarn.lock << parameters.run_all_tests_if_these_files_change >>"
                     for file in ${FILES[@]}; do
-                      if ! git diff origin/master -s --exit-code $file; then
+                      if ! git diff origin/main -s --exit-code $file; then
                         return 0
                       fi
                     done
                     return 1
                   }
 
-                  if [[ "$(git rev-parse --abbrev-ref HEAD)" == "master" ]] || important_files_modified; then
+                  if [[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]] || important_files_modified; then
                     yarn jest --coverage --reporters=default --reporters=jest-junit << parameters.args >>
                   else
-                    yarn jest --coverage --changedSince=origin/master --reporters=default --reporters=jest-junit << parameters.args >>
+                    yarn jest --coverage --changedSince=origin/main --reporters=default --reporters=jest-junit << parameters.args >>
                   fi
       - unless:
           condition: << parameters.only_test_changed >>
@@ -182,22 +182,22 @@ jobs:
             - utils/skip-if-fork-or-not-pr
             - slack/status:
                 fail_only: true
-                only_for_branches: master
-                failure_message: $CIRCLE_PROJECT_REPONAME's tests failed for master
+                only_for_branches: main
+                failure_message: $CIRCLE_PROJECT_REPONAME's tests failed for main
 
   update-cache:
     executor: node/build
     steps:
       - update_dependencies
 
-  # A job responsible for ensuring only 1 master build runs at a time so that
+  # A job responsible for ensuring only 1 main build runs at a time so that
   # there are no deployment race conditions
   workflow-queue:
     executor: node/build
     steps:
       - queue/until_front_of_line:
           time: "2" # how long a queue will wait until the job exits
-          only-on-branch: master # restrict queueing to a specific branch (default *)
+          only-on-branch: main # restrict queueing to a specific branch (default *)
           consider-job: false # block whole workflow if any job still running
 
   release:


### PR DESCRIPTION
This PR contains two types of changes:
- a hokusai version bump 
- followup to default branch rename from _master to main_

---

## Hokusai upgrade

https://artsyproduct.atlassian.net/browse/PLATFORM-3772

Hokusai orb is currently at v0.5.16 and is 2 releases behind the latest hokusai, v0.5.18.

v0.5.17 adds:
- Feat use rollout restart [#266](https://github.com/artsy/hokusai/pull/266)
- Downgrade PyYAML lib version to 5.4.1 [#271](https://github.com/artsy/hokusai/pull/271)
- feat: discontinue ecr repository exists test before run a kubectl command [#272](https://github.com/artsy/hokusai/pull/272)

v0.5.18 adds:
- feat: add image digest support to CommandRunner:run() [#276](https://github.com/artsy/hokusai/pull/276)

## Master -> Main

A number of references to the '_master_' branch needed to be updated after this project was switched to using '_main_' as the default branch. Currently, [some supporting scripts](https://app.circleci.com/pipelines/github/artsy/orbs/494/workflows/985634d5-f30d-4483-b925-8d7b68f18c61/jobs/781) for publishing orbs are broken as a result of switching this project over to '_main_'.

> NOTE: the yarn orb version needed to be bumped as a result of changes affecting yarn orb config.

https://www.notion.so/artsy/tricksy-rename-convection-f40d79cb71964ba8aed05dd3be9d2aee

As per [docs](https://github.com/artsy/README/blob/main/playbooks/rename-master-to-main.md).

To update local checkouts, developers should do:

```
git checkout master
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

---