### PR TITLE
chore: switch from legacy to next generation node image

### DIFF
--- a/src/node/node.yml
+++ b/src/node/node.yml
@@ -1,4 +1,4 @@
-# Orb Version 2.0.0
+# Orb Version 2.1.0
 
 version: 2.1
 description: Common execution environment for client-only javascript projects
@@ -7,4 +7,4 @@ executors:
   build:
     description: "Used for projects that only use node as a build tool"
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.0


### PR DESCRIPTION
A number of projects that use the artsy/yarn orb which depends on the artsy/node orb have the following notice:

<img width="722" alt="Screen Shot 2022-04-07 at 2 48 03 PM" src="https://user-images.githubusercontent.com/29984068/162275191-6c764025-8566-4cd8-81b3-fe1eb00cb229.png">

This switches from [Legacy Convenience Image](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) to [next-generation convenience image](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/).

https://circleci.com/developer/images/image/cimg/node
<img width="923" alt="Screen Shot 2022-04-07 at 2 52 40 PM" src="https://user-images.githubusercontent.com/29984068/162275953-feb11670-6151-44cb-a9aa-d5d1306fa392.png">

