### PR TITLE
chore: Pin node version to 14.18

### DIFF
--- a/src/node/node.yml
+++ b/src/node/node.yml
@@ -1,4 +1,4 @@
-# Orb Version 2.1.0
+# Orb Version 2.2.0
 
 version: 2.1
 description: Common execution environment for client-only javascript projects

--- a/src/node/node.yml
+++ b/src/node/node.yml
@@ -7,4 +7,4 @@ executors:
   build:
     description: "Used for projects that only use node as a build tool"
     docker:
-      - image: cimg/node:14.0
+      - image: cimg/node:14.18


### PR DESCRIPTION
Setting it to 14.0 (https://github.com/artsy/orbs/pull/136) made us go back some minor NodeJS versions, causing Force build to fail.

The one defined before those changes would correspond to 14.8.2.

As noted by @dblandin : 
```
$ docker run -it circleci/node:14 node --version
v14.18.2
$ docker run -it cimg/node:14.0 node --version  
v14.0.0
```

See this thread for ref:
https://artsy.slack.com/archives/C02BC3HEJ/p1649682086472439