### PR TITLE
feat: let orbs pull latest hokusai docker image

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.10.0
+# Orb Version 0.11.0
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments
@@ -6,7 +6,7 @@ description: Reusable hokusai tasks for managing deployments
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5.18
+      - image: artsy/hokusai:latest
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.14
+# Orb Version 0.1.15
 
 version: 2.1
 description: >

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -7,7 +7,7 @@ description: >
 executors:
   deploy:
     docker:
-      - image: artsy/hokusai:0.5.13
+      - image: artsy/hokusai:latest
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1649689940465819

The orbs (hokusai, remote-docker) pin the version of Hokusai. This makes updating projects rather complicated.

When there is a new version of Hokusai, the process of updating all Hokusai-managed projects to use that version, currently is:
- Publish beta orbs that point to the new Hokusai version
- Test beta orbs on a project, which involves:
  - Updating the project's `./circleci/config.yml` to use the beta orbs (requires PR)
  - When done with testing, revert that CI config to the canonical orbs (requires PR)
- It test was good, publish new orbs pointing to new Hokusai version (requires PR)
- Renovate automatically creates PRs for all(?) those projects, to point their CI config to the new orbs

The number of PRs seem excessive. And the process is actually very leaky. `remote-docker` orb, for example, is pointing to Hokusai `0.5.13` (latest is `0.5.18`). And there are [tons of projects pointing to old versions of the orbs](https://github.com/search?q=org%3Aartsy+artsy%2Fhokusai%3A&type=code) (which point to various vintage Hokusai versions?).

Because Hokusai releases are actually managed by Artsy, and that a canonical release is always preceded by a beta release, it seems we can simplify the process alot.

This PR proposes that the orbs pull `latest` Hokusai. So that when a new version of Hokusai is released, nothing has to be done for projects to use it.

Let project testing be done with the Hokusai beta release. I see no difference between testing on Hokusai beta release versus on Hokusai canonical release. If anything, testing on Beta has this advantage - any problems found can be fixed _before_ the Hokusai canonical release.

We just have to make sure we test Hokusai beta on projects. I think we've never missed doing that because it's actually hard to not consider this step as one goes through a Hokusai release.

The orbs already accept a `beta` param that tells them to pull Hokusai beta. Any project can test Hokusai beta by passing that param (one PR to update CI config). We recently [did that for Gravity](https://github.com/artsy/gravity/pull/15211).

To save us the trouble of taking a project in and out of Hokusai beta, we can simply leave one project on Hokusai beta all the time.