### PR TITLE
feat: auto uses convenience image

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,18 +1,22 @@
-# Orb Version 2.0.0
+# Orb Version 2.1.0
 
 version: 2.1
 description: Publish NPM packages and canary deployments with Intuit's Auto
 
 orbs:
   yarn: artsy/yarn@5.1.3
-  node: artsy/node@1.0.0
   auto: auto/release@0.2.3
   utils: artsy/orb-tools@0.5.0
+
+executors:
+  node:
+    docker:
+      - image: cimg/node:14.18.1
 
 jobs:
   # Publishes a package to NPM
   publish:
-    executor: node/build
+    executor: node
     environment:
       AUTO_VERSION: << parameters.version >>
     parameters:
@@ -29,7 +33,7 @@ jobs:
 
   # Publishes a canary package to npm
   publish-canary:
-    executor: node/build
+    executor: node
     environment:
       AUTO_VERSION: << parameters.version >>
     parameters:

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -22,7 +22,7 @@ jobs:
     parameters:
       version:
         type: string
-        default: v10.32.1
+        default: v10.36.5
       args:
         type: string
         default: ""
@@ -39,7 +39,7 @@ jobs:
     parameters:
       version:
         type: string
-        default: v10.32.1
+        default: v10.36.5
       args:
         type: string
         default: ""


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4129

This CL introduces two changes:

- As part of deprecating usage of artsy/node orb, this updates auto orb to use a next-gen convenience image. I chose an LTS node 14.18.1 version. Previously this orb was using the circleci/node:12 version via [artsy/node v1.0.0](https://circleci.com/developer/orbs/orb/artsy/node?version=1.0.0).
- I've also bumped the pinned auto version. Looked over the [releases](https://github.com/intuit/auto/releases) and didn't see any breaking changes

---

Side note: while looking through releases i came across two which included artsy alums as contributors. [orta](https://github.com/intuit/auto/releases/tag/v10.32.3) and [justin](https://github.com/intuit/auto/releases/tag/v10.34.0). Pretty neat.