### PR TITLE
feat: bump circleci docker engine version param.

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -27,7 +27,7 @@ commands:
     parameters:
       remote_docker_version:
         type: string
-        default: 19.03.13
+        default: 20.10.14
     steps:
       - setup
       - setup_remote_docker:
@@ -63,7 +63,7 @@ commands:
     parameters:
       remote_docker_version:
         type: string
-        default: 19.03.13
+        default: 20.10.14
     steps:
       - setup-docker:
           remote_docker_version: << parameters.remote_docker_version >>
@@ -114,7 +114,7 @@ jobs:
         description: Optional hokusai flags
       remote_docker_version:
         type: string
-        default: 19.03.13
+        default: 20.10.14
         description: specify circleci remote docker version
     steps:
       - setup-docker:
@@ -131,7 +131,7 @@ jobs:
         default: deploy
       remote_docker_version:
         type: string
-        default: 19.03.13
+        default: 20.10.14
     steps:
       - push-image:
           remote_docker_version: << parameters.remote_docker_version >>


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1662065972560309

We encountered build error with Docker engine version `19.03.13`. Error resolved by trying version `20.10.14` which is CircleCI's new default.

Bump Orb's default to `20.10.14`.