### PR TITLE
Revert "chore(yarn): bump node to 16"

### DIFF
--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 6.2.0
+# Orb Version 6.4.0
 
 version: 2.1
 description: Common yarn commands

--- a/src/yarn/yarn.yml
+++ b/src/yarn/yarn.yml
@@ -1,4 +1,4 @@
-# Orb Version 6.3.0
+# Orb Version 6.2.0
 
 version: 2.1
 description: Common yarn commands
@@ -11,7 +11,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:16.18.0
+      - image: cimg/node:14.18.1
 
 commands:
   # https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching


### PR DESCRIPTION
Reverts artsy/orbs#146

Ran into some node-gyp issues in volt when trying to install 16, so going to put this aside for now and stick with v14