### PR TITLE
fix: orb publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cli:
     docker:
-      - image: circleci/circleci-cli
+      - image: circleci/circleci-cli:0.1.25725
 
 jobs:
   validate_orbs:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ CircleCI orbs used at Artsy
 
 ## What's an Orb?
 
-CircleCI 2.1 introduces [several new features](https://github.com/CircleCI-Public/config-preview-sdk/blob/master/docs/whats-new.md#whats-new-in-21-configuration) to make sharing configuration across projects easier. Straight from their docs:
-
 > Orbs are packages of CircleCI configuration that can be shared across projects. Orbs allow you to make a single bundle of jobs, commands, and executors that can reference each other and can be imported into a CircleCI build configuration and invoked in their own namespace. Orbs are registered with CircleCI, with revisions expressed using the semver pattern.
 
-For more info on Orbs, checkout their [docs](https://github.com/CircleCI-Public/config-preview-sdk/tree/master/docs)!
+For more info on Orbs, checkout their [docs](https://circleci.com/docs/orb-intro/)!
 
-(The TL;DR is there's an `orb` yml configuration file that's used to share things like [executors][orb-executors], [commands][orb-commands], and [jobs][orb-jobs] across your CircleCi builds.)
+(The TLDR is there's an `orb` yml configuration file that's used to share things like [executors][orb-executors], [commands][orb-commands], and [jobs][orb-jobs] across your CircleCi builds.)
 
 ## Getting Started
 

--- a/scripts/publish_orb.sh
+++ b/scripts/publish_orb.sh
@@ -47,10 +47,10 @@ fi
 
 # Build CircleCI token argument
 TOKEN=""
-if [ -n "${CIRCLECI_API_KEY:-}" ]; then
-  TOKEN="--token $CIRCLECI_API_KEY"
+if [ -n "${CIRCLE_TOKEN:-}" ]; then
+  TOKEN="--token $CIRCLE_TOKEN"
 elif [ -z "$DRY_RUN" ]; then
-  echo "$(RED "Must provide CIRCLECI_API_KEY env var")"
+  echo "$(RED "Must provide CIRCLE_TOKEN env var")"
   echo ""
   exit 1
 fi

--- a/src/orb-tools/orb-tools.yml
+++ b/src/orb-tools/orb-tools.yml
@@ -1,12 +1,12 @@
-# Orb Version 0.5.0
+# Orb Version 0.5.1
 
 version: 2.1
-description: A simple set of tools for managing orbs by Artsy
+description: A simple set of tools for managing orbs at Artsy.
 
 executors:
   orb-scripts:
     docker:
-      - image: artsy/orb-scripts
+      - image: artsy/orb-scripts:latest
 
 commands:
   check-for-env-vars:
@@ -56,7 +56,7 @@ commands:
       - run:
           name: Set orb scripts path
           command: |
-            if [ ! -d "./scripts" ]; then 
+            if [ ! -d "./scripts" ]; then
               ln -s /tmp/orb-scripts scripts
             fi
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4872

As outlined in the ticket and the ticket comments the API token used for publishing orbs needs rotating to fix the publishing of orbs. This PR is used to test the new token and to verify that publishing is working as expected following token rotation. Along the way this introduces a few small changes:

- circleci config now specifies `circleci-cli` image tag, to avoid potential breaking change slipping in via usage of `latest` tag
- A small refactor is made to `orb-tools` orb improving the readability of the orb description and also specifying the tag of the (only available) image, for clarity
- [`circleci-api` context](https://app.circleci.com/settings/organization/github/artsy/contexts/896f21e5-7aa6-431f-baac-2e868052f6c8?return-to=%2F) has two tokens with identical values. `CIRCLECI_API_KEY` and `CIRCLE_TOKEN`. Both of those are used in this project. This consolidates on the usage of one token: `CIRCLE_TOKEN`
  - search shows that there was only [one reference](https://github.com/search?q=org%3Aartsy+CIRCLECI_API_KEY&type=code) to `CIRCLECI_API_KEY`, changed in this PR. we should be able to remove the redundancy within the `circleci-api` context, once this is merged.
- a small update to the project readme

### Migration

once this is approved, `CIRCLE_TOKEN` within `circleci-api` context will be rotated and then this PR merged. Expect successful publish of the `orb-tools` orb `v0.5.1` proving out that the new API key [fixed the existing issue](https://app.circleci.com/pipelines/github/artsy/orbs/543/workflows/8bf4bc25-c78b-4a90-b734-28c01171af30/jobs/877?invite=true#step-103-39).

- [x] TODO: rotate the `CIRCLE_TOKEN` token 