### PR TITLE
feat: add a job that does git push staging branch

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -173,7 +173,7 @@ jobs:
       - git-push-staging-branch-command:
           project-name: << parameters.project-name >>
 
-  git-push-staging-branch-job:
+  git-push-staging-branch:
     executor: << parameters.executor >>
     parameters:
       executor:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.12.0
+# Orb Version 0.13.0
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments
@@ -97,6 +97,16 @@ commands:
               hokusai test << parameters.flags >>
             fi
 
+  git-push-staging-branch-command:
+    parameters:
+      project-name:
+        type: string
+        description: The name of the project as it appears on github
+    steps:
+      - run:
+          name: Git Push Staging Branch
+          command: git push git@github.com:artsy/<< parameters.project-name >>.git $CIRCLE_SHA1:refs/heads/staging --force
+
 jobs:
   test:
     executor: << parameters.executor >>
@@ -160,9 +170,22 @@ jobs:
           name: Deploy
           command: hokusai staging deploy $CIRCLE_SHA1 --update-config
           no_output_timeout: << parameters.time-out >>
-      - run:
-          name: Update Staging branch
-          command: git push git@github.com:artsy/<< parameters.project-name >>.git $CIRCLE_SHA1:refs/heads/staging --force
+      - git-push-staging-branch-command:
+          project-name: << parameters.project-name >>
+
+  git-push-staging-branch-job:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        type: executor
+        default: deploy
+      project-name:
+        type: string
+        description: The name of the project as it appears on github
+    steps:
+      - setup
+      - git-push-staging-branch-command:
+          project-name: << parameters.project-name >>
 
   retag-staging:
     executor: << parameters.executor >>


### PR DESCRIPTION
To support an immediate use case of Fulcrum pipeline's Staging CI step doing `git push` to `staging` branch.

This Git push is already provided by Hokusai orb as part of `deploy-staging` job but the job also does Kubernetes deploy which we don't want for Fulcrum.

So let the orb have a distinct step for `git push` to `staging` branch.

The job is [tested on hokusai-sandbox project](https://github.com/artsy/hokusai-sandbox/pull/67/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R66).