### PR TITLE
fix: missing bash fi

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.18
+# Orb Version 0.1.19
 
 version: 2.1
 description: >
@@ -113,6 +113,7 @@ commands:
                   --tag="${BUILD_TAG}" \
                   --skip-latest
                 printf "%s Image pushed.\n" "$(TZ=UTC date)"
+              fi
 
               printf "Skipping local docker build fallback...\n"
             fi
@@ -169,6 +170,7 @@ commands:
                 --tag="$CIRCLE_SHA1" \
                 --skip-latest
               printf "%s Image pushed.\n" "$(TZ=UTC date)"
+            fi
 
   test:
     steps:


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1684786887702399

Add missing Bash `fi`.

Fallout from https://github.com/artsy/orbs/pull/152