### PR TITLE
fix: hokusai registry images grep

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,5 @@
-# Orb Version 0.13.0
+# Orb Version 0.14.0
+
 
 version: 2.1
 description: Reusable hokusai tasks for managing deployments
@@ -71,9 +72,8 @@ commands:
           name: Push
           command: |
             set +euo pipefail
-            if hokusai registry images --limit 1000 | grep -q $CIRCLE_SHA1; then
-              echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry"
-            else
+            if hokusai registry images --limit 1000 | grep $CIRCLE_SHA1 >/dev/null; then
+              echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry" else
               hokusai registry push --tag $CIRCLE_SHA1
             fi
 

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.19
+# Orb Version 0.1.20
 
 version: 2.1
 description: >
@@ -101,9 +101,10 @@ commands:
               if [ ! -z "${BUILD_TARGET}" ]; then
                 TAG_LABEL="-${BUILD_TARGET}"
               fi
+
               export BUILD_TAG="${CIRCLE_SHA1}${TAG_LABEL}"
 
-              if hokusai registry images --limit 1000 | grep -q $CIRCLE_SHA1; then
+              if hokusai registry images --limit 1000 | grep $BUILD_TAG >/dev/null; then
                 echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
               else
                 printf "%s Pushing image...\n" "$(TZ=UTC date)"
@@ -129,17 +130,19 @@ commands:
               source $BASH_ENV
 
               printf "%s Building image...\n" "$(TZ=UTC date)"
-              BUILD_TARGET="$BUILD_TARGET" BUILD_TAG="$CIRCLE_SHA1" hokusai build
+              export BUILD_TARGET="$BUILD_TARGET"
+              export BUILD_TAG="$CIRCLE_SHA1"
+              hokusai build
               printf "%s Image built.\n" "$(TZ=UTC date)"
 
-              if hokusai registry images --limit 1000 | grep -q $CIRCLE_SHA1; then
-                echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry"
+              if hokusai registry images --limit 1000 | grep $BUILD_TAG >/dev/null; then
+                echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
               else
                 printf "%s Pushing image...\n" "$(TZ=UTC date)"
                 hokusai registry push \
                   --no-build \
-                  --local-tag="$CIRCLE_SHA1" \
-                  --tag="$CIRCLE_SHA1" \
+                  --local-tag="$BUILD_TAG" \
+                  --tag="$BUILD_TAG" \
                   --skip-latest
                 printf "%s Image pushed.\n" "$(TZ=UTC date)"
               fi
@@ -157,17 +160,19 @@ commands:
           no_output_timeout: 15m
           command: |
             printf "%s Building image...\n" "$(TZ=UTC date)"
-            BUILD_TARGET="$BUILD_TARGET" BUILD_TAG="$CIRCLE_SHA1" hokusai build
+            export BUILD_TARGET="$BUILD_TARGET"
+            export BUILD_TAG="$CIRCLE_SHA1"
+            hokusai build
             printf "%s Image built.\n" "$(TZ=UTC date)"
 
-            if hokusai registry images --limit 1000 | grep -q $CIRCLE_SHA1; then
-              echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry"
+            if hokusai registry images --limit 1000 | grep $BUILD_TAG >/dev/null; then
+              echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
             else
               printf "%s Pushing image...\n" "$(TZ=UTC date)"
               hokusai registry push \
                 --no-build \
-                --local-tag="$CIRCLE_SHA1" \
-                --tag="$CIRCLE_SHA1" \
+                --local-tag="$BUILD_TAG" \
+                --tag="$BUILD_TAG" \
                 --skip-latest
               printf "%s Image pushed.\n" "$(TZ=UTC date)"
             fi


### PR DESCRIPTION
[PLATFORM-5205]

- Replace `grep -q` with `grep...>/dev/null`
- Standardizing `grep`s to use `BUILD_TAG`

Lightly tested with a [Force branch build](https://app.circleci.com/pipelines/github/artsy/force/49026/workflows/d41cc6fe-6d38-4646-9b34-0709f79c3ffd).

[PLATFORM-5205]: https://artsyproduct.atlassian.net/browse/PLATFORM-5205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ