### PR TITLE
fix: loose grep

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -72,7 +72,8 @@ commands:
           name: Push
           command: |
             set +euo pipefail
-            if hokusai registry images --limit 1000 | grep "$CIRCLE_SHA1" | grep -v "${CIRCLE_SHA1}-" >/dev/null
+
+            if hokusai registry images --limit 1000 | grep -E "$CIRCLE_SHA1([, ]|$)" >/dev/null
             then
               echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry"
             else

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.15.0
+# Orb Version 0.16.0
 
 
 version: 2.1
@@ -72,7 +72,8 @@ commands:
           name: Push
           command: |
             set +euo pipefail
-            if hokusai registry images --limit 1000 | grep $CIRCLE_SHA1 >/dev/null; then
+            if hokusai registry images --limit 1000 | grep "$CIRCLE_SHA1" | grep -v "${CIRCLE_SHA1}-" >/dev/null
+            then
               echo "Skipping push as the tag $CIRCLE_SHA1 already exists in the Docker registry"
             else
               hokusai registry push --tag $CIRCLE_SHA1

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -104,7 +104,7 @@ commands:
 
               export BUILD_TAG="${CIRCLE_SHA1}${TAG_LABEL}"
 
-              if hokusai registry images --limit 1000 | grep "$BUILD_TAG" | grep -v "${BUILD_TAG}-" >/dev/null
+              if hokusai registry images --limit 1000 | grep -E "$BUILD_TAG([, ]|$)" >/dev/null
               then
                 echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
               else
@@ -136,7 +136,7 @@ commands:
               hokusai build
               printf "%s Image built.\n" "$(TZ=UTC date)"
 
-              if hokusai registry images --limit 1000 | grep "$BUILD_TAG" | grep -v "${BUILD_TAG}-" >/dev/null
+              if hokusai registry images --limit 1000 | grep -E "$BUILD_TAG([, ]|$)" >/dev/null
               then
                 echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
               else
@@ -167,7 +167,7 @@ commands:
             hokusai build
             printf "%s Image built.\n" "$(TZ=UTC date)"
 
-            if hokusai registry images --limit 1000 | grep "$BUILD_TAG" | grep -v "${BUILD_TAG}-" >/dev/null
+            if hokusai registry images --limit 1000 | grep -E "$BUILD_TAG([, ]|$)" >/dev/null
             then
               echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
             else

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.20
+# Orb Version 0.1.21
 
 version: 2.1
 description: >
@@ -104,7 +104,8 @@ commands:
 
               export BUILD_TAG="${CIRCLE_SHA1}${TAG_LABEL}"
 
-              if hokusai registry images --limit 1000 | grep $BUILD_TAG >/dev/null; then
+              if hokusai registry images --limit 1000 | grep "$BUILD_TAG" | grep -v "${BUILD_TAG}-" >/dev/null
+              then
                 echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
               else
                 printf "%s Pushing image...\n" "$(TZ=UTC date)"
@@ -135,7 +136,8 @@ commands:
               hokusai build
               printf "%s Image built.\n" "$(TZ=UTC date)"
 
-              if hokusai registry images --limit 1000 | grep $BUILD_TAG >/dev/null; then
+              if hokusai registry images --limit 1000 | grep "$BUILD_TAG" | grep -v "${BUILD_TAG}-" >/dev/null
+              then
                 echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
               else
                 printf "%s Pushing image...\n" "$(TZ=UTC date)"
@@ -165,7 +167,8 @@ commands:
             hokusai build
             printf "%s Image built.\n" "$(TZ=UTC date)"
 
-            if hokusai registry images --limit 1000 | grep $BUILD_TAG >/dev/null; then
+            if hokusai registry images --limit 1000 | grep "$BUILD_TAG" | grep -v "${BUILD_TAG}-" >/dev/null
+            then
               echo "Skipping push as the tag $BUILD_TAG already exists in the Docker registry"
             else
               printf "%s Pushing image...\n" "$(TZ=UTC date)"


### PR DESCRIPTION
Co-authored with @joeyAghion, @anandaroop 

The [`grep` fix](https://github.com/artsy/orbs/pull/154) [surfaced](https://artsy.slack.com/archives/CP9P4KR35/p1685557174108749) that the `grep` is too loose, that is, a grep for `666aec93a2eb0c69ce7f937404746bab643472f4` matches these as well:

```
~/code/force$ hokusai registry images --limit=1000 | grep 666aec93a2eb0c69ce7f937404746bab643472f4
2023-05-31 10:20:22-04:00 | 63a4e6508e165d77bbe41f715186441daa348153-electron-runner, 585d2b5167808f687cffd916930a6ba2b6f666a3-electron-runner, 666aec93a2eb0c69ce7f937404746bab643472f4-electron-runner
2023-05-31 10:17:50-04:00 | 585d2b5167808f687cffd916930a6ba2b6f666a3-builder, 63a4e6508e165d77bbe41f715186441daa348153-builder, 666aec93a2eb0c69ce7f937404746bab643472f4-builder
```

Tighten the grep by including comma-space or end of line.