### PR TITLE
feat: support different configure between hokusai v1 and v2

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.17.0
+# Orb Version 0.18.0
 
 
 version: 2.1

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -56,9 +56,19 @@ commands:
       - run:
           name: Configure Hokusai
           command: |
-            mkdir -p ~/.hokusai
-            curl -o ~/.hokusai/config.yml << parameters.configUri >>
-            hokusai configure
+            # sed removes color code from hokusai output
+            version=$(hokusa version | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")
+            echo "hokusai version: $version"
+            major=${version:0:1}
+
+            if [ "$major" -lt "2" ]
+            then
+              mkdir -p ~/.hokusai
+              curl -o ~/.hokusai/config.yml << parameters.configUri >>
+              hokusai configure
+            else
+              HOKUSAI_GLOBAL_CONFIG=s3://artsy-provisioning-public/hokusai/config-ci.yml hokusai configure
+            fi
 
   push-image:
     parameters:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -56,18 +56,18 @@ commands:
       - run:
           name: Configure Hokusai
           command: |
-            # sed removes color code from hokusai output
-            version=$(hokusai version | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")
-            echo "hokusai version: $version"
-            major=${version:0:1}
-
-            if [ "$major" -lt "2" ]
+            # configure differently for old/new configure command
+            kubectl_version_option=$(hokusai configure --help | grep kubectl-version)
+            if [ -z "$kubectl_version_option" ]
             then
+              # kubectl_version_option is null, --help has no kubectl-version option
+              echo "New Hokusai configure command."
+              HOKUSAI_GLOBAL_CONFIG=s3://artsy-provisioning-public/hokusai/config-ci.yml hokusai configure
+            else
+              echo "Old Hokusai configure command."
               mkdir -p ~/.hokusai
               curl -o ~/.hokusai/config.yml << parameters.configUri >>
               hokusai configure
-            else
-              HOKUSAI_GLOBAL_CONFIG=s3://artsy-provisioning-public/hokusai/config-ci.yml hokusai configure
             fi
 
   push-image:

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -57,7 +57,7 @@ commands:
           name: Configure Hokusai
           command: |
             # sed removes color code from hokusai output
-            version=$(hokusa version | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")
+            version=$(hokusai version | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g")
             echo "hokusai version: $version"
             major=${version:0:1}
 


### PR DESCRIPTION
Hokusai v2 will soon be released with a [breaking change on `hokusai configure` command](https://github.com/artsy/hokusai/pull/379). If we simply release Hokusai v2, the `configure` command in this Orb will break. Therefore, update this Orb to work with v2 while still supporting v1. After v2 is released we will come back here to remove v1 logiic.