### PR TITLE
docs(yarn): Add note deprecating artsy/yarn in favor of circleci/node

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 CircleCI orbs used at Artsy
 
+⚠️ [`artsy/yarn`](https://github.com/artsy/orbs/tree/main/src/yarn) has now been deprecated in favor of [`circleci/node`](https://circleci.com/developer/orbs/orb/circleci/node). Please use that for all Node.js-based CI needs.
+
 ## What's an Orb?
 
 > Orbs are packages of CircleCI configuration that can be shared across projects. Orbs allow you to make a single bundle of jobs, commands, and executors that can reference each other and can be imported into a CircleCI build configuration and invoked in their own namespace. Orbs are registered with CircleCI, with revisions expressed using the semver pattern.

--- a/src/yarn/README.md
+++ b/src/yarn/README.md
@@ -1,3 +1,5 @@
 # artsy/yarn
 
+⚠️ [`artsy/yarn`](https://github.com/artsy/orbs/tree/main/src/yarn) has now been deprecated in favor of [`circleci/node`](https://circleci.com/developer/orbs/orb/circleci/node). Please use that for all Node.js-based CI needs.
+
 This orb contains the bulk of Artsy's commonly used [yarn](https://yarnpkg.com/en/) commands that power the builds for our frontend and Node projects.


### PR DESCRIPTION
The excellent `artsy/yarn` was written before circleci released their version of the node orb. Now that that is in place (and it handles all of the functionality that artsy/yarn provides and more), lets mark this as deprecated. 

I've been [updating repos that I come across](https://github.com/artsy/metaphysics/pull/5235), but I think there might be a few more left. Force still needs to be done.  