### PR TITLE
feat: allow specifying node version in auto orb

### DIFF
--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,13 +1,11 @@
 # Orb Version 2.1.0
 
 version: 2.1
-description: Publish NPM packages and canary deployments with Intuit's Auto
-
+description: "Publish NPM packages and canary deployments with Intuit's Auto"
 orbs:
   yarn: artsy/yarn@5.1.3
   auto: auto/release@0.2.3
   utils: artsy/orb-tools@0.5.0
-
 executors:
   node:
     parameters:
@@ -16,9 +14,7 @@ executors:
         default: "14.18.1"
     docker:
       - image: cimg/node:<< parameters.node-version >>
-
 jobs:
-  # Publishes a package to NPM
   publish:
     parameters:
       node-version:
@@ -38,9 +34,7 @@ jobs:
     steps:
       - yarn/pre-release
       - auto/shipit:
-        arguments: << parameters.args >>
-
-  # Publishes a canary package to npm
+          arguments: << parameters.args >>
   publish-canary:
     parameters:
       node-version:
@@ -59,8 +53,8 @@ jobs:
       AUTO_VERSION: << parameters.version >>
     steps:
       - utils/skip-if-fork-or-not-pr:
-          pr-skip-message: Skipping, only deploys canaries on PR builds
-          fork-skip-message: Skipping, can't deploy canaries from a fork
+          pr-skip-message: "Skipping, only deploys canaries on PR builds"
+          fork-skip-message: "Skipping, can't deploy canaries from a fork"
       - yarn/pre-release
       - auto/canary:
-        arguments: << parameters.args >>
+          arguments: << parameters.args >>

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,7 +1,7 @@
 # Orb Version 2.2.0
 
-version: 2.2
-description: "Publish NPM packages and canary deployments with Intuit's Auto"
+version: 2.1
+description: Publish NPM packages and canary deployments with Intuit's Auto
 orbs:
   yarn: artsy/yarn@5.1.3
   auto: auto/release@0.2.3
@@ -53,8 +53,8 @@ jobs:
       AUTO_VERSION: << parameters.version >>
     steps:
       - utils/skip-if-fork-or-not-pr:
-          pr-skip-message: "Skipping, only deploys canaries on PR builds"
-          fork-skip-message: "Skipping, can't deploy canaries from a fork"
+          pr-skip-message: Skipping, only deploys canaries on PR builds
+          fork-skip-message: Skipping, can't deploy canaries from a fork
       - yarn/pre-release
       - auto/canary:
           arguments: << parameters.args >>

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -10,22 +10,31 @@ orbs:
 
 executors:
   node:
+    parameters:
+      node-version:
+        type: string
+        default: "14.18.1"
     docker:
-      - image: cimg/node:14.18.1
+      - image: cimg/node:<< parameters.node-version >>
 
 jobs:
   # Publishes a package to NPM
   publish:
-    executor: node
-    environment:
-      AUTO_VERSION: << parameters.version >>
     parameters:
+      node-version:
+        type: string
+        default: "14.18.1"
       version:
         type: string
         default: v10.36.5
       args:
         type: string
         default: ""
+    executor:
+      name: node
+      node-version: << parameters.node-version >>
+    environment:
+      AUTO_VERSION: << parameters.version >>
     steps:
       - yarn/pre-release
       - auto/shipit:
@@ -33,16 +42,21 @@ jobs:
 
   # Publishes a canary package to npm
   publish-canary:
-    executor: node
-    environment:
-      AUTO_VERSION: << parameters.version >>
     parameters:
+      node-version:
+        type: string
+        default: "14.18.1"
       version:
         type: string
         default: v10.36.5
       args:
         type: string
         default: ""
+    executor:
+      name: node
+      node-version: << parameters.node-version >>
+    environment:
+      AUTO_VERSION: << parameters.version >>
     steps:
       - utils/skip-if-fork-or-not-pr:
           pr-skip-message: Skipping, only deploys canaries on PR builds

--- a/src/auto/auto.yml
+++ b/src/auto/auto.yml
@@ -1,6 +1,6 @@
-# Orb Version 2.1.0
+# Orb Version 2.2.0
 
-version: 2.1
+version: 2.2
 description: "Publish NPM packages and canary deployments with Intuit's Auto"
 orbs:
   yarn: artsy/yarn@5.1.3


### PR DESCRIPTION
Some recent changes in palette-mobile to update dependencies started failing because a node version >= 16 was required and this orb was hardcoded to 14. 
https://app.circleci.com/pipelines/github/artsy/palette-mobile/494/workflows/8a89277f-bedc-424e-b82d-8e1ea4c88fcb/jobs/1093

This allows specifying a node version for the executor with the default still being 14.
Passing job using an inline version of these changes here: 
https://app.circleci.com/pipelines/github/artsy/palette-mobile/496/workflows/432344ba-a514-42f4-829b-0d922c1c0e67/jobs/1104

Passing job with canary: https://app.circleci.com/pipelines/github/artsy/palette-mobile/497/workflows/d6945495-464a-409f-9493-b7cbe3738922/jobs/1108
