### PR TITLE
chore: bump remote docker version to 23

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -28,7 +28,7 @@ commands:
     parameters:
       remote_docker_version:
         type: string
-        default: 20.10.14
+        default: docker23
     steps:
       - setup
       - setup_remote_docker:
@@ -62,7 +62,7 @@ commands:
     parameters:
       remote_docker_version:
         type: string
-        default: 20.10.14
+        default: docker23
     steps:
       - setup-docker:
           remote_docker_version: << parameters.remote_docker_version >>
@@ -125,7 +125,7 @@ jobs:
         description: Optional hokusai flags
       remote_docker_version:
         type: string
-        default: 20.10.14
+        default: docker23
         description: specify circleci remote docker version
     steps:
       - setup-docker:
@@ -142,7 +142,7 @@ jobs:
         default: deploy
       remote_docker_version:
         type: string
-        default: 20.10.14
+        default: docker23
     steps:
       - push-image:
           remote_docker_version: << parameters.remote_docker_version >>

--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.21.0
+# Orb Version 0.22.0
 
 
 version: 2.1


### PR DESCRIPTION
This PR bumps the default docker image used for our deployment pipelines `test` and `push` steps from `20.10.14` to `23.x`. 

### Motivation
We received an email from circleci notifying us that we are using images that will reach EOL by September 30th, 2024. While that is far away, the change is minimal, and it will be good to resolve now before we are affected by the planned brownouts. The emails indicate that the images affected are used in our `push-staging-image` and `test` [steps](https://github.com/artsy/orbs/blob/main/src/hokusai/hokusai.yml#L112-L148), which I can see is using the [deprecated image](https://app.circleci.com/pipelines/github/artsy/motion/4885/workflows/0163764b-09df-4f02-b2f7-753d91a3ac6c/jobs/3794?invite=true#step-0-0_117). See slack thread for [more discussion](https://artsy.slack.com/archives/CA8SANW3W/p1708695109870689).

### Considerations
- We're make a jump from `v20` to `v23`, but this is the oldest supported version, so we don't seem to have a choice. 
- We should consider if we want to switch to `default` at some point.
- See circleci docs for their [remote docker versioning policy](https://circleci.com/docs/remote-docker-images-support-policy/#tagging). 

I would love to test this but not sure how other than just push and see if our pipelines start breaking. Let me know if you have ideas. 