### PR TITLE
feat: bump tag to their mutable latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM circleci/circleci-cli:0.1.5691-alpine
+FROM circleci/circleci-cli:alpine
 COPY ./scripts /tmp/orb-scripts
 RUN apk add --no-cache bash git curl jq


### PR DESCRIPTION
0.1.5691-alpine is based on Alpine 3.8. We find that its `curl` is [not able to validate the Cloudflare-managed *.artsy.net SSL certificate](https://artsy.slack.com/archives/C02BC3HEJ/p1714656940656779).

Let's update the Docker tag to just `alpine`. That is a mutable tag that will always point to CircleCI's latest.

