### PR TITLE
feat: switch base image to plain old alpine [migration]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM circleci/circleci-cli:alpine
+FROM alpine:latest
 COPY ./scripts /tmp/orb-scripts
 RUN apk add --no-cache bash git curl jq


### PR DESCRIPTION
[Previous tag change](https://github.com/artsy/orbs/pull/165) did not help because the latest circleci-cli alpine image is still based on Alpine 3.8.

Assuming that `artsy/orb-scripts` Docker image is used only for [release Orb](https://github.com/artsy/orbs/blob/main/src/release/release.yml), and nothing in the Orb relies on any of the extra tools provided by circleci-cli image, let's just use plain old Alpine as base image.

Migration (done):
---
```
docker build -t artsy/orb-scripts:latest .
docker push artsy/orb-scripts:latest
```