### PR TITLE
fix: up docker image version to recommended version

### DIFF
--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.1.22
+# Orb Version 0.1.23
 
 version: 2.1
 description: >

--- a/src/remote-docker/remote-docker.yml
+++ b/src/remote-docker/remote-docker.yml
@@ -199,7 +199,7 @@ jobs:
       - add_ssh_keys
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 23.0.6
       - test
 
   build:
@@ -226,7 +226,7 @@ jobs:
           artsy_s3_path_root: << parameters.artsy_s3_path_root >>
       - build-image-via-artsy
       - setup_remote_docker:
-          version: 19.03.13
+          version: 23.0.6
       - build-image-via-circle
 
   buildkit-build:


### PR DESCRIPTION
Version we're currently using is getting deprecated in September and undergoing brown outs today. Upping it to the version recommended by [CircleCI](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176).