### PR TITLE
fix: update hokusai orb default remote docker version to be compatible with docker-cli 28

### DIFF
--- a/src/hokusai/hokusai.yml
+++ b/src/hokusai/hokusai.yml
@@ -1,4 +1,4 @@
-# Orb Version 0.25.0
+# Orb Version 0.26.0
 
 
 version: 2.1
@@ -28,7 +28,7 @@ commands:
     parameters:
       remote_docker_version:
         type: string
-        default: docker23
+        default: default
     steps:
       - setup
       - setup_remote_docker:
@@ -62,7 +62,7 @@ commands:
     parameters:
       remote_docker_version:
         type: string
-        default: docker23
+        default: default
       working-directory:
         type: string
         default: ""
@@ -141,7 +141,7 @@ jobs:
         description: Optional hokusai flags
       remote_docker_version:
         type: string
-        default: docker23
+        default: default
         description: specify circleci remote docker version
       working-directory:
         type: string
@@ -163,7 +163,7 @@ jobs:
         default: deploy
       remote_docker_version:
         type: string
-        default: docker23
+        default: default
       working-directory:
         type: string
         default: ""


### PR DESCRIPTION
Changed `setup-docker` command `default` from `docker23` to `default` (Docker 24) to fix incompatibility between hokusai's docker-cli 28 (API 1.52) and CircleCI's Docker 23 remote engine (max API 1.42).

This PR fixes [the issue](https://app.circleci.com/pipelines/github/artsy/exchange/14238/workflows/cdad06a8-617d-4d20-ade5-4379dc763de3/jobs/29017) on Exchange's CI. 

```
Server Engine Details:
  Version:          23.0.6
  API version:      1.42 (minimum version 1.12)
  Go version:       go1.19.9
  Git commit:       9dbdbd4
  Built:            2023-05-05T21:18:13.000000000+00:00
  OS/Arch:          linux/amd64
  Experimental:     false
```

### Ticket
https://artsyproduct.atlassian.net/browse/PHIRE-2876